### PR TITLE
DEV-7485: updated to handle new orders api.

### DIFF
--- a/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/Orders.java
+++ b/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/Orders.java
@@ -44,8 +44,11 @@ public class Orders
     @Test
     public void Upsert_Simple_Order() throws ApiException {
         String testScope = "TestScope-" +  UUID.randomUUID().toString();
-        String orderId = "Order-" +  UUID.randomUUID().toString();
-
+        String orderCode = "Order-" +  UUID.randomUUID().toString();
+        ResourceId orderId = new ResourceId()
+                .code(orderCode)
+                .scope(testScope);
+        
         // These instrument identifiers should all map to the same instrument. If the instance of
         // LUSID has the specified instruments registered these identifiers will get resolved to
         // an actual internal instrument on upsert; otherwise, they'll be resolved to instrument or
@@ -71,24 +74,24 @@ public class Orders
         properties.put("Order/" + testScope + "/Strategy", new PerpetualProperty().key("Order/" + testScope + "/Strategy").value(new PropertyValue().labelValue("RiskArb")));
 
         OrderRequest request = new OrderRequest()
-                .code(orderId)
+                .id(orderId)
                 .quantity(100)
-                .portfolio(portfolio)
+                .portfolioId(portfolio)
                 .properties(properties)
                 .instrumentIdentifiers(instruments)
                 .side("Buy")
-                .orderBook(orderBook);
+                .orderBookId(orderBook);
 
         OrderSetRequest requestSet = new OrderSetRequest()
                 .addOrderRequestsItem(request);
 
         // We can ask the Orders API to upsert this order for us
-        List<Order> upsertResult = ordersApi.upsertOrders(testScope, requestSet).getValues();
+        List<Order> upsertResult = ordersApi.upsertOrders(requestSet).getValues();
 
         // The return gives us a list of orders upserted. The LUID for each has been mapped from the
         // instrument identifiers passed
         assertEquals(1, upsertResult.stream().count());
-        assertTrue(upsertResult.stream().allMatch(order -> order.getId().getCode().equals(orderId)));
+        assertTrue(upsertResult.stream().allMatch(order -> order.getId().getCode().equals(orderCode)));
         assertTrue(upsertResult.stream().allMatch(order -> order.getLusidInstrumentId().equals(instrumentIds.get(0))));
     }
 
@@ -97,7 +100,10 @@ public class Orders
     @Test
     public void Upsert_Simple_Order_With_Unknown_Instrument() throws ApiException {
         String testScope = "TestScope-" +  UUID.randomUUID().toString();
-        String orderId = "Order-" +  UUID.randomUUID().toString();
+        String orderCode = "Order-" +  UUID.randomUUID().toString();
+        ResourceId orderId = new ResourceId()
+                .code(orderCode)
+                .scope(testScope);
 
         // These instrument identifiers should all map to the same instrument. If the instance of
         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -124,19 +130,19 @@ public class Orders
         properties.put("Order/" + testScope + "/Strategy", new PerpetualProperty().key("Order/" + testScope + "/Strategy").value(new PropertyValue().labelValue("RiskArb")));
 
         OrderRequest request = new OrderRequest()
-                .code(orderId)
+                .id(orderId)
                 .quantity(100)
-                .portfolio(portfolio)
+                .portfolioId(portfolio)
                 .properties(properties)
                 .instrumentIdentifiers(instruments)
                 .side("Buy")
-                .orderBook(orderBook);
+                .orderBookId(orderBook);
 
         OrderSetRequest requestSet = new OrderSetRequest()
                 .addOrderRequestsItem(request);
 
         // We can ask the Orders API to upsert this order for us
-        List<Order> upsertResult = ordersApi.upsertOrders(testScope, requestSet).getValues();
+        List<Order> upsertResult = ordersApi.upsertOrders(requestSet).getValues();
 
         // The return gives us a list of orders upserted, and the LUID for each has been mapped from the
         // instrument identifiers passed
@@ -149,7 +155,10 @@ public class Orders
     @Test
     public void Update_Simple_Order() throws ApiException {
         String testScope = "TestScope-" +  UUID.randomUUID().toString();
-        String orderId = "Order-" +  UUID.randomUUID().toString();
+        String orderCode = "Order-" +  UUID.randomUUID().toString();
+        ResourceId orderId = new ResourceId()
+                .code(orderCode)
+                .scope(testScope);
 
         // These instrument identifiers should all map to the same instrument. If the instance of
         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -176,43 +185,43 @@ public class Orders
         properties.put("Order/" + testScope + "/Strategy", new PerpetualProperty().key("Order/" + testScope + "/Strategy").value(new PropertyValue().labelValue("RiskArb")));
 
         OrderRequest request = new OrderRequest()
-                .code(orderId)
+                .id(orderId)
                 .quantity(100)
-                .portfolio(portfolio)
+                .portfolioId(portfolio)
                 .properties(properties)
                 .instrumentIdentifiers(instruments)
                 .side("Buy")
-                .orderBook(orderBook);
+                .orderBookId(orderBook);
 
         OrderSetRequest requestSet = new OrderSetRequest()
                 .addOrderRequestsItem(request);
 
         // We can ask the Orders API to upsert this order for us
-        List<Order> upsertResult = ordersApi.upsertOrders(testScope, requestSet).getValues();
+        List<Order> upsertResult = ordersApi.upsertOrders(requestSet).getValues();
 
         // The return gives us a list of orders upserted, and the lusidinstrument for each has been mapped from the
         // instrument identifiers passed
         assertEquals(1, upsertResult.stream().count());
-        assertTrue(upsertResult.stream().allMatch(order -> order.getId().getCode().equals(orderId)));
+        assertTrue(upsertResult.stream().allMatch(order -> order.getId().getCode().equals(orderCode)));
         assertTrue(upsertResult.stream().allMatch(order -> order.getLusidInstrumentId().equals(instrumentIds.get(0))));
         assertTrue(upsertResult.stream().allMatch(order -> order.getQuantity().equals(100)));
         assertTrue(upsertResult.stream().allMatch(order -> order.getProperties().size() == 5));
 
         // We can update that Order with a new Quantity, and some extra parameters
         OrderRequest updateRequest = new OrderRequest()
-                .code(orderId)
+                .id(orderId)
                 .quantity(500)
-                .portfolio(portfolio)
+                .portfolioId(portfolio)
                 .properties(properties)
                 .instrumentIdentifiers(instruments)
                 .side("Buy")
-                .orderBook(orderBook);
+                .orderBookId(orderBook);
 
         OrderSetRequest updateRequestSet = new OrderSetRequest()
                 .addOrderRequestsItem(updateRequest);
 
         // We can ask the Orders API to upsert this order for us
-        List<Order> updateResult = ordersApi.upsertOrders(testScope, updateRequestSet).getValues();
+        List<Order> updateResult = ordersApi.upsertOrders(updateRequestSet).getValues();
 
         // The return gives us a list of orders upserted, and the lusidinstrument for each has been mapped from the
         // instrument identifiers passed. We can see that the quantity has been udpated, and properties added
@@ -225,10 +234,18 @@ public class Orders
     @Test
     public void Upsert_And_Retrieve_Simple_Orders() throws ApiException {
         String testScope = "TestScope-" +  UUID.randomUUID().toString();
-        String orderId1 = "Order-" +  UUID.randomUUID().toString();
-        String orderId2 = "Order-" +  UUID.randomUUID().toString();
-        String orderId3 = "Order-" +  UUID.randomUUID().toString();
-
+        String orderCode1 = "Order-" +  UUID.randomUUID().toString();
+        String orderCode2 = "Order-" +  UUID.randomUUID().toString();
+        String orderCode3 = "Order-" +  UUID.randomUUID().toString();
+        ResourceId orderId1 = new ResourceId()
+                .code(orderCode1)
+                .scope(testScope);
+        ResourceId orderId2 = new ResourceId()
+                .code(orderCode2)
+                .scope(testScope);
+        ResourceId orderId3 = new ResourceId()
+                .code(orderCode3)
+                .scope(testScope);
 
         // These instrument identifiers should all map to the same instrument. If the instance of
         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -265,31 +282,31 @@ public class Orders
         altProperties.put("Order/" + testScope + "/OrderGroup", new PerpetualProperty().key("Order/" + testScope + "/OrderGroup").value(new PropertyValue().labelValue("UK Test Orders 2")));
 
         OrderRequest request1 = new OrderRequest()
-                .code(orderId1)
+                .id(orderId1)
                 .quantity(100)
-                .portfolio(portfolio)
+                .portfolioId(portfolio)
                 .properties(properties)
                 .instrumentIdentifiers(instruments)
                 .side("Sell")
-                .orderBook(orderBook);
+                .orderBookId(orderBook);
 
         OrderRequest request2 = new OrderRequest()
-            .code(orderId2)
+            .id(orderId2)
             .quantity(200)
-            .portfolio(portfolio)
+            .portfolioId(portfolio)
             .properties(properties)
             .instrumentIdentifiers(instruments)
                 .side("Buy")
-                .orderBook(orderBook);
+                .orderBookId(orderBook);
 
         OrderRequest request3 = new OrderRequest()
-                .code(orderId3)
+                .id(orderId3)
                 .quantity(300)
-                .portfolio(portfolio)
+                .portfolioId(portfolio)
                 .properties(altProperties)
                 .instrumentIdentifiers(altInstruments)
                 .side("Buy")
-                .orderBook(anotherOrderBook);
+                .orderBookId(anotherOrderBook);
 
         OrderSetRequest request = new OrderSetRequest()
                 .addOrderRequestsItem(request1)
@@ -297,7 +314,7 @@ public class Orders
                 .addOrderRequestsItem(request3);
 
         // We can ask the Orders API to upsert this order for us
-        ResourceListOfOrder upsertResult = ordersApi.upsertOrders(testScope, request);
+        ResourceListOfOrder upsertResult = ordersApi.upsertOrders(request);
 
         // The return gives us a list of orders upserted, and the lusidinstrument for each has been mapped from the
         // instrument identifiers passed
@@ -305,24 +322,24 @@ public class Orders
 
         OffsetDateTime t = upsertResult.getValues().get(0).getVersion().getAsAtDate();
 
-        List<Order> quantityFilter = ordersApi.listOrders(testScope, t, null, null, null, null,"Quantity gt 100", null).getValues();
+        List<Order> quantityFilter = ordersApi.listOrders(t, null, null, null, null,"Quantity gt 100 and Scope eq '" + testScope + "'", null).getValues();
         assertEquals(2, quantityFilter.size());
         assertTrue(quantityFilter.stream().allMatch(order -> order.getQuantity() > 100));
 
-        List<Order> orderGroupFilter = ordersApi.listOrders(testScope, t, null, null, null, null,"Properties[" + testScope + "/OrderGroup] eq 'UK Test Orders 2'", null).getValues();
+        List<Order> orderGroupFilter = ordersApi.listOrders(t, null, null, null, null,"Properties[" + testScope + "/OrderGroup] eq 'UK Test Orders 2'", null).getValues();
         assertEquals(1, orderGroupFilter.size());
         assertTrue(orderGroupFilter.stream().allMatch(order -> order.getProperties().get("Order/" + testScope + "/OrderGroup").getValue().getLabelValue().equals("UK Test Orders 2")));
 
-        List<Order> instrumentFilter = ordersApi.listOrders(testScope, t, null, null, null, null,"LusidInstrumentId eq '" + instrumentIds.get(0) + "'", null).getValues();
+        List<Order> instrumentFilter = ordersApi.listOrders(t, null, null, null, null,"LusidInstrumentId eq '" + instrumentIds.get(0) + "' and Scope eq '" + testScope + "'", null).getValues();
         assertEquals(2, instrumentFilter.size());
         assertTrue(instrumentFilter.stream().allMatch(order -> order.getLusidInstrumentId().equals(instrumentIds.get(0))));
 
-        List<Order> sideFilter = ordersApi.listOrders(testScope, t, null, null, null, null,"Side eq 'Sell'", null).getValues();
+        List<Order> sideFilter = ordersApi.listOrders(t, null, null, null, null,"Side eq 'Sell' and Scope eq '" + testScope + "'", null).getValues();
         assertEquals(1, sideFilter.size());
         assertTrue(sideFilter.stream().allMatch(order -> order.getSide().equals("Sell")));
 
-        List<Order> orderBookFilter = ordersApi.listOrders(testScope, t, null, null, null, null,"OrderBook eq '" + testScope + "/AnotherOrdersTestBook'", null).getValues();
+        List<Order> orderBookFilter = ordersApi.listOrders(t, null, null, null, null,"OrderBook eq '" + testScope + "/AnotherOrdersTestBook'", null).getValues();
         assertEquals(1, orderBookFilter.size());
-        assertTrue(orderBookFilter.stream().allMatch(order -> order.getOrderBook().getCode().equals("AnotherOrdersTestBook")));
+        assertTrue(orderBookFilter.stream().allMatch(order -> order.getOrderBookId().getCode().equals("AnotherOrdersTestBook")));
     }
 }


### PR DESCRIPTION
This reverts commit 31f5f9846bf1c15294e3f22d715a776a83cb51e4, reapplying this change.

# Pull Request Checklist

- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Updating tests to handle removal of scope from routes, assorted other API changes.
