### PR TITLE
DEV-8132 : ApiClient Factory : Refreshing Token

### DIFF
--- a/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
@@ -4,6 +4,7 @@ import com.finbourne.lusid.ApiClient;
 import com.finbourne.lusid.utilities.auth.HttpLusidTokenProvider;
 import com.finbourne.lusid.utilities.auth.KeepAuthTokenProvider;
 import com.finbourne.lusid.utilities.auth.LusidToken;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
 import okhttp3.OkHttpClient;
 
 import java.io.IOException;
@@ -22,8 +23,12 @@ public class ApiClientBuilder {
      *
      * @param apiSecretsFilename
      * @return
+     *
+     * @throws ApiConfigurationException on failing to create a valid {@link ApiConfiguration} from the provided
+     * secrets file or system environment variables
+     * @throws LusidTokenException on failing to authenticate and retrieve an initial {@link LusidToken}
      */
-    public ApiClient build(String apiSecretsFilename){
+    public ApiClient build(String apiSecretsFilename) throws ApiConfigurationException, LusidTokenException {
         // setup configuration from secrets file
         ApiConfiguration apiConfiguration = createApiConfiguration(apiSecretsFilename);
         // http client to use for api and auth calls
@@ -52,12 +57,8 @@ public class ApiClientBuilder {
         return  apiClient;
     }
 
-    private ApiConfiguration createApiConfiguration(String apiSecretsFilename){
-        try {
-            return new ApiConfigurationBuilder().build(apiSecretsFilename);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to build API Configuration. Ensure secrets files is properly setup.", e);
-        }
+    private ApiConfiguration createApiConfiguration(String apiSecretsFilename) throws ApiConfigurationException {
+        return new ApiConfigurationBuilder().build(apiSecretsFilename);
     }
 
     private OkHttpClient createHttpClient(ApiConfiguration apiConfiguration){

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
@@ -1,91 +1,56 @@
 package com.finbourne.lusid.utilities;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.finbourne.lusid.ApiClient;
-import okhttp3.*;
+import com.finbourne.lusid.utilities.auth.HttpLusidTokenProvider;
+import com.finbourne.lusid.utilities.auth.KeepAuthTokenProvider;
+import com.finbourne.lusid.utilities.auth.LusidToken;
+import okhttp3.OkHttpClient;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 /**
  * Utility class to build an ApiClient from a set of configuration
  */
 public class ApiClientBuilder {
 
-    private static final MediaType FORM = MediaType.parse("application/x-www-form-urlencoded");
+    public ApiClient build(String apiSecretsFilename){
+        // setup configuration from secrets file
+        ApiConfiguration apiConfiguration = createApiConfiguration(apiSecretsFilename);
+        // http client to use for api and auth calls
+        OkHttpClient httpClient = createHttpClient(apiConfiguration);
 
-    public ApiClient build(String apiSecretsFilename) throws IOException
-    {
-        ApiConfiguration    apiConfiguration = new ApiConfigurationBuilder().build(apiSecretsFilename);
+        // token provider to keep client authenticated with automated token refreshing
+        KeepAuthTokenProvider keepAuthTokenProvider = new KeepAuthTokenProvider(new HttpLusidTokenProvider(apiConfiguration, httpClient));
+        LusidToken lusidToken = keepAuthTokenProvider.get();
 
-        //  request body
-        final String    tokenRequestBody = String.format("grant_type=password&username=%s&password=%s&scope=openid client groups&client_id=%s&client_secret=%s",
-                apiConfiguration.getUsername(),
-                URLEncoder.encode(apiConfiguration.getPassword(), StandardCharsets.UTF_8.toString()),
-                apiConfiguration.getClientId(),
-                URLEncoder.encode(apiConfiguration.getClientSecret(), StandardCharsets.UTF_8.toString()));
+        // setup api client that managed submissions with latest token
+        ApiClient defaultApiClient = createDefaultApiClient(apiConfiguration, httpClient, lusidToken);
+        return new KeepLiveApiClient(defaultApiClient, keepAuthTokenProvider);
+    }
 
-        final OkHttpClient    httpClient;
-
-        //  use a proxy if given
-        if (apiConfiguration.getProxyAddress() != null) {
-
-            InetSocketAddress proxy = new InetSocketAddress(apiConfiguration.getProxyAddress(), apiConfiguration.getProxyPort());
-
-            httpClient = new OkHttpClient.Builder()
-                    .proxy(new Proxy(Proxy.Type.HTTP, proxy))
-                    .proxyAuthenticator((route, response) -> {
-                        String credential = Credentials.basic(apiConfiguration.getProxyUsername(), apiConfiguration.getProxyPassword());
-                        return response.request().newBuilder()
-                                .header("Proxy-Authorization", credential)
-                                .build();
-                    })
-                    .build();
-        }
-        else {
-            httpClient = new OkHttpClient();
-        }
-
-        final RequestBody body = RequestBody.create(FORM, tokenRequestBody);
-        final Request request = new Request.Builder()
-                .url(apiConfiguration.getTokenUrl())
-                .header("Accept", "application/json")
-                .post(body)
-                .build();
-
-        Response response = httpClient.newCall(request).execute();
-
-        if (response.code() != 200) {
-            throw new IOException(response.toString());
-        }
-
-        final String    content = response.body().string();
-        final ObjectMapper mapper = new ObjectMapper();
-
-        //  map json response
-        final Map bodyValues = mapper.readValue(content, Map.class);
-
-        if (!bodyValues.containsKey("access_token")) {
-            throw new IOException("missing access_token");
-        }
-
-        //  get access token
-        final String apiToken = (String)bodyValues.get("access_token");
-
-        ApiClient   apiClient = new ApiClient();
+    private ApiClient createDefaultApiClient(ApiConfiguration apiConfiguration, OkHttpClient httpClient, LusidToken lusidToken){
+        ApiClient apiClient = new ApiClient();
 
         if (apiConfiguration.getProxyAddress() != null) {
             apiClient.setHttpClient(httpClient);
         }
 
-        apiClient.addDefaultHeader("Authorization", "Bearer " + apiToken);
+        apiClient.addDefaultHeader("Authorization", "Bearer " + lusidToken.getAccessToken());
         apiClient.addDefaultHeader("X-LUSID-Application", apiConfiguration.getApplicationName());
         apiClient.setBasePath(apiConfiguration.getApiUrl());
 
-        return apiClient;
+        return  apiClient;
+    }
+
+    private ApiConfiguration createApiConfiguration(String apiSecretsFilename){
+        try {
+            return new ApiConfigurationBuilder().build(apiSecretsFilename);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to build API Configuration. Ensure secrets files is properly setup.", e);
+        }
+    }
+
+    private OkHttpClient createHttpClient(ApiConfiguration apiConfiguration){
+        return new HttpClientBuilder().build(apiConfiguration);
     }
 }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
@@ -13,6 +13,16 @@ import java.io.IOException;
  */
 public class ApiClientBuilder {
 
+    /**
+     * Builds an ApiClient implementation configured against a secrets file. Typically used
+     * for communicating with LUSID via the APIs (e.g. {@link com.finbourne.lusid.api.TransactionPortfoliosApi}, {@link com.finbourne.lusid.api.QuotesApi}.
+     *
+     * ApiClient implementation enables use of REFRESH tokens (see https://support.finbourne.com/using-a-refresh-token)
+     * and automatically handles token refreshing on expiry.
+     *
+     * @param apiSecretsFilename
+     * @return
+     */
     public ApiClient build(String apiSecretsFilename){
         // setup configuration from secrets file
         ApiConfiguration apiConfiguration = createApiConfiguration(apiSecretsFilename);

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/ApiClientBuilder.java
@@ -7,8 +7,6 @@ import com.finbourne.lusid.utilities.auth.LusidToken;
 import com.finbourne.lusid.utilities.auth.LusidTokenException;
 import okhttp3.OkHttpClient;
 
-import java.io.IOException;
-
 /**
  * Utility class to build an ApiClient from a set of configuration
  */
@@ -40,7 +38,7 @@ public class ApiClientBuilder {
 
         // setup api client that managed submissions with latest token
         ApiClient defaultApiClient = createDefaultApiClient(apiConfiguration, httpClient, lusidToken);
-        return new KeepLiveApiClient(defaultApiClient, keepAuthTokenProvider);
+        return new KeepAuthApiClient(defaultApiClient, keepAuthTokenProvider);
     }
 
     private ApiClient createDefaultApiClient(ApiConfiguration apiConfiguration, OkHttpClient httpClient, LusidToken lusidToken){

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/ApiConfigurationBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/ApiConfigurationBuilder.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class ApiConfigurationBuilder {
 
-    public ApiConfiguration build(String apiSecretsFilename) throws IOException {
+    public ApiConfiguration build(String apiSecretsFilename) throws ApiConfigurationException {
 
         //  firstly try and get the values from environment variables
         String tokenUrl = System.getenv("FBN_TOKEN_URL");
@@ -29,28 +29,33 @@ public class ApiConfigurationBuilder {
 
         if (tokenUrl == null || username == null || password == null || clientId == null || clientSecret == null || apiUrl == null) {
 
-            File configJson = new ConfigurationLoader().loadConfiguration(apiSecretsFilename);
+            try {
+                File configJson = new ConfigurationLoader().loadConfiguration(apiSecretsFilename);
 
-            //  load configuration from secrets.json if any of the environment variables are missing
-            ObjectMapper configMapper = new ObjectMapper();
-            Map apiConfigValues = configMapper.readValue(configJson, Map.class);
-            Map apiConfig = (Map)apiConfigValues.get("api");
+                //  load configuration from secrets.json if any of the environment variables are missing
+                ObjectMapper configMapper = new ObjectMapper();
+                Map apiConfigValues = configMapper.readValue(configJson, Map.class);
+                Map apiConfig = (Map) apiConfigValues.get("api");
 
-            tokenUrl = (String)apiConfig.get("tokenUrl");
-            username = (String)apiConfig.get("username");
-            password = (String)apiConfig.get("password");
-            clientId = (String)apiConfig.get("clientId");
-            clientSecret = (String)apiConfig.get("clientSecret");
-            apiUrl = (String)apiConfig.get("apiUrl");
-            applicationName = apiConfig.containsKey("applicationName") ? (String)apiConfig.get("applicationName") : null;
+                tokenUrl = (String) apiConfig.get("tokenUrl");
+                username = (String) apiConfig.get("username");
+                password = (String) apiConfig.get("password");
+                clientId = (String) apiConfig.get("clientId");
+                clientSecret = (String) apiConfig.get("clientSecret");
+                apiUrl = (String) apiConfig.get("apiUrl");
+                applicationName = apiConfig.containsKey("applicationName") ? (String) apiConfig.get("applicationName") : null;
 
-            if (apiConfigValues.containsKey("proxy")) {
-                Map proxyConfig = (Map)apiConfigValues.get("proxy");
+                if (apiConfigValues.containsKey("proxy")) {
+                    Map proxyConfig = (Map) apiConfigValues.get("proxy");
 
-                proxyAddress = (String)proxyConfig.get("proxyAddress");
-                proxyPort = (Integer)proxyConfig.get("proxyPort");
-                proxyUsername = (String)proxyConfig.get("username");
-                proxyPassword = (String)proxyConfig.get("password");
+                    proxyAddress = (String) proxyConfig.get("proxyAddress");
+                    proxyPort = (Integer) proxyConfig.get("proxyPort");
+                    proxyUsername = (String) proxyConfig.get("username");
+                    proxyPassword = (String) proxyConfig.get("password");
+                }
+
+            } catch (IOException e){
+                throw new ApiConfigurationException("Error when loading details from configuration file. See details : ", e);
             }
 
         }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/ApiConfigurationException.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/ApiConfigurationException.java
@@ -1,0 +1,16 @@
+package com.finbourne.lusid.utilities;
+
+/**
+ * Exception on failing to build a valid {@link ApiConfiguration}
+ *
+ */
+public class ApiConfigurationException extends Exception{
+
+    public ApiConfigurationException(String message){
+        super(message);
+    }
+
+    public ApiConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/HttpClientBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/HttpClientBuilder.java
@@ -6,8 +6,19 @@ import okhttp3.OkHttpClient;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 
+/**
+ * Builds http client to communicate to LUSID API instances.
+ *
+ */
 public class HttpClientBuilder {
 
+    /**
+     *  Builds a {@link OkHttpClient} from a {@link ApiConfiguration} to make
+     *  calls to the LUSID API.
+     *
+     * @param apiConfiguration configuration to connect to LUSID API
+     * @return an client for http calls to LUSID API
+     */
     public OkHttpClient build(ApiConfiguration apiConfiguration){
         final OkHttpClient httpClient;
 

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/HttpClientBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/HttpClientBuilder.java
@@ -1,0 +1,35 @@
+package com.finbourne.lusid.utilities;
+
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+public class HttpClientBuilder {
+
+    public OkHttpClient build(ApiConfiguration apiConfiguration){
+        final OkHttpClient httpClient;
+
+        //  use a proxy if given
+        if (apiConfiguration.getProxyAddress() != null) {
+
+            InetSocketAddress proxy = new InetSocketAddress(apiConfiguration.getProxyAddress(), apiConfiguration.getProxyPort());
+
+            httpClient = new OkHttpClient.Builder()
+                    .proxy(new Proxy(Proxy.Type.HTTP, proxy))
+                    .proxyAuthenticator((route, response) -> {
+                        String credential = Credentials.basic(apiConfiguration.getProxyUsername(), apiConfiguration.getProxyPassword());
+                        return response.request().newBuilder()
+                                .header("Proxy-Authorization", credential)
+                                .build();
+                    })
+                    .build();
+        }
+        else {
+            httpClient = new OkHttpClient();
+        }
+        return httpClient;
+    }
+
+}

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/KeepAuthApiClient.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/KeepAuthApiClient.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * API.
  *
  */
-public class KeepLiveApiClient extends ApiClient {
+public class KeepAuthApiClient extends ApiClient {
 
     /** Default api client to delegate actual request execution*/
     private final ApiClient apiClient;
@@ -26,7 +26,7 @@ public class KeepLiveApiClient extends ApiClient {
     /** Token provider to retrieve valid {@link LusidToken} */
     private final KeepAuthTokenProvider tokenProvider;
 
-    public KeepLiveApiClient(ApiClient apiClient, KeepAuthTokenProvider tokenProvider) {
+    public KeepAuthApiClient(ApiClient apiClient, KeepAuthTokenProvider tokenProvider) {
         this.apiClient = apiClient;
         this.tokenProvider = tokenProvider;
     }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/KeepLiveApiClient.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/KeepLiveApiClient.java
@@ -1,0 +1,39 @@
+package com.finbourne.lusid.utilities;
+
+import com.finbourne.lusid.ApiCallback;
+import com.finbourne.lusid.ApiClient;
+import com.finbourne.lusid.ApiException;
+import com.finbourne.lusid.Pair;
+import com.finbourne.lusid.utilities.auth.LusidToken;
+import com.finbourne.lusid.utilities.auth.KeepAuthTokenProvider;
+import okhttp3.Call;
+
+import java.util.List;
+import java.util.Map;
+
+public class KeepLiveApiClient extends ApiClient {
+
+    private final ApiClient apiClient;
+    private final KeepAuthTokenProvider tokenProvider;
+
+    public KeepLiveApiClient(ApiClient apiClient, KeepAuthTokenProvider tokenProvider) {
+        this.apiClient = apiClient;
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
+        setAccessToken(tokenProvider.get());
+        return apiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, callback);
+    }
+
+    /**
+     *  set api client to use latest token
+     *
+     * @param accessToken
+     */
+    private void setAccessToken(LusidToken accessToken) {
+        apiClient.addDefaultHeader("Authorization", "Bearer " + accessToken.getAccessToken());
+    }
+
+}

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/KeepLiveApiClient.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/KeepLiveApiClient.java
@@ -6,14 +6,24 @@ import com.finbourne.lusid.ApiException;
 import com.finbourne.lusid.Pair;
 import com.finbourne.lusid.utilities.auth.LusidToken;
 import com.finbourne.lusid.utilities.auth.KeepAuthTokenProvider;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
 import okhttp3.Call;
 
 import java.util.List;
 import java.util.Map;
 
+/**
+ * An extension of the {@link ApiClient} that always updates the clients authorisation
+ * header to use a valid {@link LusidToken} access tokens before any calls to LUSID
+ * API.
+ *
+ */
 public class KeepLiveApiClient extends ApiClient {
 
+    /** Default api client to delegate actual request execution*/
     private final ApiClient apiClient;
+
+    /** Token provider to retrieve valid {@link LusidToken} */
     private final KeepAuthTokenProvider tokenProvider;
 
     public KeepLiveApiClient(ApiClient apiClient, KeepAuthTokenProvider tokenProvider) {
@@ -21,17 +31,26 @@ public class KeepLiveApiClient extends ApiClient {
         this.tokenProvider = tokenProvider;
     }
 
+    /**
+     * Wraps around the default {@link ApiClient} implementation to ensure the client always uses
+     * a valid {@link LusidToken}.
+     *
+     * Delegates actual call to the default {@link ApiClient} implementation once the authorisation
+     * header has been set to use a valid token.
+     *
+     * @return
+     * @throws ApiException
+     */
     @Override
     public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        setAccessToken(tokenProvider.get());
+        try {
+            setAccessToken(tokenProvider.get());
+        } catch (LusidTokenException e) {
+            throw new ApiException(e);
+        }
         return apiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, callback);
     }
 
-    /**
-     *  set api client to use latest token
-     *
-     * @param accessToken
-     */
     private void setAccessToken(LusidToken accessToken) {
         apiClient.addDefaultHeader("Authorization", "Bearer " + accessToken.getAccessToken());
     }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/LusidApiFactoryBuilder.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/LusidApiFactoryBuilder.java
@@ -1,8 +1,7 @@
 package com.finbourne.lusid.utilities;
 
 import com.finbourne.lusid.ApiClient;
-
-import java.io.IOException;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
 
 public class LusidApiFactoryBuilder {
 
@@ -11,9 +10,9 @@ public class LusidApiFactoryBuilder {
      *
      * @return
      */
-    public static LusidApiFactory build() throws IOException {
+    public static LusidApiFactory build() throws ApiConfigurationException, LusidTokenException {
         if (!areRequiredEnvironmentVariablesSet()) {
-            throw new IllegalStateException("Environment variables to configure LUSID API client have not been set. See " +
+            throw new ApiConfigurationException("Environment variables to configure LUSID API client have not been set. See " +
                     " see https://support.lusid.com/getting-started-with-apis-sdks for details.");
         }
         return createLusidApiFactory("");
@@ -22,7 +21,7 @@ public class LusidApiFactoryBuilder {
     /**
      * Build a {@link LusidApiFactory} using the specified configuration file. For details on the format of the configuration file see https://support.lusid.com/getting-started-with-apis-sdks.
      */
-    public static LusidApiFactory build(String configurationFile) throws IOException {
+    public static LusidApiFactory build(String configurationFile) throws ApiConfigurationException, LusidTokenException {
         return createLusidApiFactory(configurationFile);
     }
 
@@ -33,7 +32,7 @@ public class LusidApiFactoryBuilder {
         throw new UnsupportedOperationException("Connecting to LUSID via flat access tokens is not yet supported in the LUSID java sdk.");
     }
 
-    private static LusidApiFactory createLusidApiFactory(String configurationFile) throws IOException {
+    private static LusidApiFactory createLusidApiFactory(String configurationFile) throws ApiConfigurationException, LusidTokenException {
         ApiClient apiClient = new ApiClientBuilder().build(configurationFile);
         return new LusidApiFactory(apiClient);
     }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProvider.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProvider.java
@@ -1,0 +1,117 @@
+package com.finbourne.lusid.utilities.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.finbourne.lusid.utilities.ApiConfiguration;
+import okhttp3.*;
+import org.apache.commons.codec.binary.Base64;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+public class HttpLusidTokenProvider {
+
+    private static final MediaType FORM = MediaType.parse("application/x-www-form-urlencoded");
+
+    /** Scope to ensure refresh token included in auth request (for details see https://support.finbourne.com/using-a-refresh-token)*/
+    private static final String SCOPE = "openid client groups offline_access";
+
+    private final ApiConfiguration apiConfiguration;
+    private final OkHttpClient httpClient;
+
+    public HttpLusidTokenProvider(ApiConfiguration apiConfiguration, OkHttpClient httpClient) {
+        this.apiConfiguration = apiConfiguration;
+        this.httpClient = httpClient;
+    }
+
+    public LusidToken getToken(Optional<String> refreshToken) {
+        final Request request = createAccessTokenRequest(refreshToken);
+        final LusidToken lusidToken = callAndMapResponseToToken(httpClient, request);
+        return lusidToken;
+    }
+
+    private LusidToken callAndMapResponseToToken(OkHttpClient httpClient, Request request){
+        //  map json response
+        try {
+            Response response = httpClient.newCall(request).execute();
+
+            if (response.code() != 200) {
+                throw new RuntimeException("Authentication call to LUSID failed. See response :" + response.toString());
+            }
+
+            final String content = response.body().string();
+            final ObjectMapper mapper = new ObjectMapper();
+            final Map bodyValues = mapper.readValue(content, Map.class);
+
+
+            if (!bodyValues.containsKey("access_token")) {
+                throw new IOException("missing access_token");
+            }
+
+            if (!bodyValues.containsKey("refresh_token")) {
+                throw new IOException("missing refresh_token");
+            }
+
+            if (!bodyValues.containsKey("expires_in")) {
+                throw new IOException("missing expires_in");
+            }
+
+            //  get access token, refresh token and token expiry
+            final String apiToken = (String)bodyValues.get("access_token");
+            final String refreshToken = (String)bodyValues.get("refresh_token");
+            final int expires_in = (int)bodyValues.get("expires_in");
+
+            LusidToken lusidToken = new LusidToken(apiToken, refreshToken, calculateExpiryAtTime(LocalDateTime.now(), expires_in));
+            return lusidToken;
+        } catch (IOException e){
+            throw new RuntimeException("Authentication response does not appear to valid. See details:", e);
+        }
+    }
+
+    private Request createAccessTokenRequest(Optional<String> refreshStringOpt){
+        //  request body
+        final String tokenRequestBody;
+        try {
+            if (!refreshStringOpt.isPresent()) {
+                // if no refresh token is present then go through the entire authetication flow
+                tokenRequestBody = String.format("grant_type=password&username=%s&password=%s&scope=%s&client_id=%s&client_secret=%s",
+                        apiConfiguration.getUsername(),
+                        URLEncoder.encode(apiConfiguration.getPassword(), StandardCharsets.UTF_8.toString()),
+                        SCOPE,
+                        apiConfiguration.getClientId(),
+                        URLEncoder.encode(apiConfiguration.getClientSecret(), StandardCharsets.UTF_8.toString()));
+            } else {
+                // otherwise if a refresh token is present than request a refreshed access token only
+                tokenRequestBody = String.format("grant_type=refresh_token&scope=%s&refresh_token=%s",
+                        SCOPE,
+                        refreshStringOpt.get());
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to encode parameters from the API Configuration. Ensure your secrets files is properly setup.", e);
+        }
+
+        final RequestBody body = RequestBody.create(FORM, tokenRequestBody);
+        final Request.Builder requestBuilder = new Request.Builder()
+                .url(apiConfiguration.getTokenUrl())
+                .header("Accept", "application/json")
+                .post(body);
+
+        if (refreshStringOpt.isPresent()) {
+            requestBuilder.addHeader("Authorization", "Basic " +
+                    Base64.encodeBase64String((apiConfiguration.getClientId() + ":" + apiConfiguration.getClientSecret()).getBytes()));
+        }
+
+        return requestBuilder.build();
+    }
+
+    LocalDateTime calculateExpiryAtTime(LocalDateTime now, int expires_in){
+        // expiration is shortened to overcome a race condition where the token is still valid when retrieved from cache but expired when used
+        // replicate behaviour in c# sdk
+        return now.plusSeconds(expires_in - 30);
+    }
+
+}

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProvider.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProvider.java
@@ -13,14 +13,23 @@ import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Provides {@link LusidToken} used for API authentication by directly querying the authentication
+ * token urls on the target LUSID instance. Always provides REFRESHable tokens (see
+ * https://support.finbourne.com/using-a-refresh-token).
+ *
+ */
 public class HttpLusidTokenProvider {
+
+    /** Scope to ensure refresh token is enabled */
+    private static final String SCOPE = "openid client groups offline_access";
 
     private static final MediaType FORM = MediaType.parse("application/x-www-form-urlencoded");
 
-    /** Scope to ensure refresh token included in auth request (for details see https://support.finbourne.com/using-a-refresh-token)*/
-    private static final String SCOPE = "openid client groups offline_access";
-
+    /** configuration parameters to connect to LUSID */
     private final ApiConfiguration apiConfiguration;
+
+    /** client to make http calls to LUSID */
     private final OkHttpClient httpClient;
 
     public HttpLusidTokenProvider(ApiConfiguration apiConfiguration, OkHttpClient httpClient) {
@@ -28,7 +37,16 @@ public class HttpLusidTokenProvider {
         this.httpClient = httpClient;
     }
 
-    public LusidToken getToken(Optional<String> refreshToken) {
+    /**
+     * Retrieves a {@link LusidToken} via an authentication call to LUSID.
+     *
+     * Will make a complete authentication call (with username and password) if no refresh token
+     * is available. Otherwise will attempt to refresh the token.
+     *
+     * @param refreshToken - to attempt token refresh with it is available.
+     * @return an authenticated LUSID token
+     */
+    public LusidToken get(Optional<String> refreshToken) {
         final Request request = createAccessTokenRequest(refreshToken);
         final LusidToken lusidToken = callAndMapResponseToToken(httpClient, request);
         return lusidToken;
@@ -109,8 +127,8 @@ public class HttpLusidTokenProvider {
     }
 
     LocalDateTime calculateExpiryAtTime(LocalDateTime now, int expires_in){
-        // expiration is shortened to overcome a race condition where the token is still valid when retrieved from cache but expired when used
-        // replicate behaviour in c# sdk
+        // expiration is shortened to overcome a race condition where the token is still valid when retrieved from cache but expired when
+        // used in an api call
         return now.plusSeconds(expires_in - 30);
     }
 

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
@@ -1,5 +1,6 @@
 package com.finbourne.lusid.utilities.auth;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -32,8 +33,10 @@ public class KeepAuthTokenProvider {
      * will subsequently manage refreshing the token after expiry
      *
      * @return a live and valid {@link LusidToken}
+     *
+     * @throws LusidTokenException on failing to authenticate and retrieve a token
      */
-    public synchronized LusidToken get(){
+    public synchronized LusidToken get() throws LusidTokenException {
         if (currentToken == null) {
             currentToken = httpLusidTokenProvider.get(Optional.empty());
         } else if (isTokenExpired(currentToken)) {

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
@@ -1,8 +1,9 @@
 package com.finbourne.lusid.utilities.auth;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Provides {@link LusidToken} used for API authentication and manages
@@ -11,6 +12,8 @@ import java.util.Optional;
  *
  */
 public class KeepAuthTokenProvider {
+
+    private final Logger logger = Logger.getLogger(getClass().getName());
 
     /** Underlying token provider that authenticates against LUSID*/
     private final HttpLusidTokenProvider httpLusidTokenProvider;
@@ -30,7 +33,7 @@ public class KeepAuthTokenProvider {
 
     /**
      * Stores an initial {@link LusidToken} on complete authentication (with username and password) and
-     * will subsequently manage refreshing the token after expiry
+     * will subsequently manage refreshing the token after expiry.
      *
      * @return a live and valid {@link LusidToken}
      *
@@ -40,7 +43,13 @@ public class KeepAuthTokenProvider {
         if (currentToken == null) {
             currentToken = httpLusidTokenProvider.get(Optional.empty());
         } else if (isTokenExpired(currentToken)) {
-            currentToken = httpLusidTokenProvider.get(Optional.of(currentToken.getRefreshToken()));
+            try {
+                currentToken = httpLusidTokenProvider.get(Optional.of(currentToken.getRefreshToken()));
+            } catch (LusidTokenException e){
+                logger.log(Level.WARNING, "Authentication call to refresh token has failed. Attempting to reauthenticate " +
+                        " fully with credentials. See details for refresh failure:", e);
+                currentToken = httpLusidTokenProvider.get(Optional.empty());
+            }
         }
         return currentToken;
     }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
@@ -1,0 +1,28 @@
+package com.finbourne.lusid.utilities.auth;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public class KeepAuthTokenProvider {
+
+    private final HttpLusidTokenProvider httpLusidTokenProvider;
+    private LusidToken currentToken;
+
+    public KeepAuthTokenProvider(HttpLusidTokenProvider httpLusidTokenProvider) {
+        this.httpLusidTokenProvider = httpLusidTokenProvider;
+    }
+
+    public synchronized LusidToken get(){
+        if (currentToken == null) {
+            currentToken = httpLusidTokenProvider.getToken(Optional.empty());
+        } else if (isTokenExpired(currentToken)) {
+            currentToken = httpLusidTokenProvider.getToken(Optional.of(currentToken.getRefreshToken()));
+        }
+        return currentToken;
+    }
+
+    public boolean isTokenExpired(LusidToken token){
+        return LocalDateTime.now().isAfter(token.getExpiresAt());
+    }
+
+}

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProvider.java
@@ -3,24 +3,51 @@ package com.finbourne.lusid.utilities.auth;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+/**
+ * Provides {@link LusidToken} used for API authentication and manages
+ * token expiry to ensure continued connectivity to LUSID API without the need
+ * for explicit reauthentication by the caller.
+ *
+ */
 public class KeepAuthTokenProvider {
 
+    /** Underlying token provider that authenticates against LUSID*/
     private final HttpLusidTokenProvider httpLusidTokenProvider;
+
+    /** Current token in use for API calls*/
     private LusidToken currentToken;
 
+    /**
+     * Creates a KeepAuthTokenProvider based on an underlying token provider
+     * that manages direct authentication with LUSID.
+     *
+     * @param httpLusidTokenProvider underlying provider that manages explicit authentication calls to LUSID
+     */
     public KeepAuthTokenProvider(HttpLusidTokenProvider httpLusidTokenProvider) {
         this.httpLusidTokenProvider = httpLusidTokenProvider;
     }
 
+    /**
+     * Stores an initial {@link LusidToken} on complete authentication (with username and password) and
+     * will subsequently manage refreshing the token after expiry
+     *
+     * @return a live and valid {@link LusidToken}
+     */
     public synchronized LusidToken get(){
         if (currentToken == null) {
-            currentToken = httpLusidTokenProvider.getToken(Optional.empty());
+            currentToken = httpLusidTokenProvider.get(Optional.empty());
         } else if (isTokenExpired(currentToken)) {
-            currentToken = httpLusidTokenProvider.getToken(Optional.of(currentToken.getRefreshToken()));
+            currentToken = httpLusidTokenProvider.get(Optional.of(currentToken.getRefreshToken()));
         }
         return currentToken;
     }
 
+    /**
+     * Checks if a token has expired
+     *
+     * @param token to check expiry on
+     * @return true if token expired false otherwise
+     */
     public boolean isTokenExpired(LusidToken token){
         return LocalDateTime.now().isAfter(token.getExpiresAt());
     }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/LusidToken.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/LusidToken.java
@@ -1,0 +1,28 @@
+package com.finbourne.lusid.utilities.auth;
+
+import java.time.LocalDateTime;
+
+public class LusidToken {
+
+    private final String accessToken;
+    private final String refreshToken;
+    private final LocalDateTime expiresAt;
+
+    public LusidToken(String accessToken, String refreshToken, LocalDateTime expiresAt) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiresAt = expiresAt;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/LusidToken.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/LusidToken.java
@@ -1,11 +1,21 @@
 package com.finbourne.lusid.utilities.auth;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
+/**
+ * Container for token information required to authenticate against LUSID.
+ *
+ */
 public class LusidToken {
 
+    /** Token used against API calls for authentication */
     private final String accessToken;
+
+    /** Token used to refresh existing access token on expiry */
     private final String refreshToken;
+
+    /** Expiry time of the current access token */
     private final LocalDateTime expiresAt;
 
     public LusidToken(String accessToken, String refreshToken, LocalDateTime expiresAt) {
@@ -24,5 +34,20 @@ public class LusidToken {
 
     public LocalDateTime getExpiresAt() {
         return expiresAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LusidToken that = (LusidToken) o;
+        return Objects.equals(accessToken, that.accessToken) &&
+                Objects.equals(refreshToken, that.refreshToken) &&
+                Objects.equals(expiresAt, that.expiresAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accessToken, refreshToken, expiresAt);
     }
 }

--- a/sdk/src/main/java/com/finbourne/lusid/utilities/auth/LusidTokenException.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/auth/LusidTokenException.java
@@ -1,0 +1,16 @@
+package com.finbourne.lusid.utilities.auth;
+
+/**
+ * Exception for errors and issues related to retrieving {@link LusidToken}
+ *
+ */
+public class LusidTokenException extends Exception{
+
+    public LusidTokenException(String message){
+        super(message);
+    }
+
+    public LusidTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/Orders.java
+++ b/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/Orders.java
@@ -6,8 +6,10 @@ import com.finbourne.lusid.api.InstrumentsApi;
 import com.finbourne.lusid.api.OrdersApi;
 import com.finbourne.lusid.model.*;
 import com.finbourne.lusid.utilities.ApiClientBuilder;
+import com.finbourne.lusid.utilities.ApiConfigurationException;
 import com.finbourne.lusid.utilities.CredentialsSource;
 import com.finbourne.lusid.utilities.InstrumentLoader;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -29,7 +31,7 @@ public class Orders
     private static List<String> instrumentIds;
 
     @BeforeClass
-    public static void setUp() throws ApiException, IOException {
+    public static void setUp() throws Exception {
         ApiClient apiClient = new ApiClientBuilder().build(CredentialsSource.credentialsFile);
 
         InstrumentsApi instrumentsApi = new InstrumentsApi(apiClient);

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/ApiClientBuilderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/ApiClientBuilderIT.java
@@ -1,10 +1,7 @@
 package com.finbourne.lusid.utilities;
 
 import com.finbourne.lusid.ApiClient;
-import com.finbourne.lusid.utilities.auth.HttpLusidTokenProvider;
-import com.finbourne.lusid.utilities.auth.KeepAuthTokenProvider;
 import com.finbourne.lusid.utilities.auth.LusidTokenException;
-import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +31,7 @@ public class ApiClientBuilderIT {
         ApiClient apiClient = apiClientBuilder.build(CredentialsSource.credentialsFile);
         // running with no exceptions ensures client built correctly with no configuration or token creation exceptions
         assertThat("Unexpected extended implementation of ApiClient for default build." ,
-                apiClient, instanceOf(KeepLiveApiClient.class));
+                apiClient, instanceOf(KeepAuthApiClient.class));
     }
 
     @Test

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/ApiClientBuilderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/ApiClientBuilderIT.java
@@ -1,0 +1,53 @@
+package com.finbourne.lusid.utilities;
+
+import com.finbourne.lusid.ApiClient;
+import com.finbourne.lusid.utilities.auth.HttpLusidTokenProvider;
+import com.finbourne.lusid.utilities.auth.KeepAuthTokenProvider;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class ApiClientBuilderIT {
+
+    private ApiClientBuilder apiClientBuilder;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp(){
+        apiClientBuilder = new ApiClientBuilder();
+    }
+
+    @Test
+    public void build_OnValidConfigurationFile_ShouldBuildKeepLiveApiClient() throws ApiConfigurationException, LusidTokenException {
+        // This test assumes default secrets file is valid. Same assertion as all other integration tests.
+        ApiClient apiClient = apiClientBuilder.build(CredentialsSource.credentialsFile);
+        // running with no exceptions ensures client built correctly with no configuration or token creation exceptions
+        assertThat("Unexpected extended implementation of ApiClient for default build." ,
+                apiClient, instanceOf(KeepLiveApiClient.class));
+    }
+
+    @Test
+    public void build_OnNonExistingConfigurationFile_ShouldThrowException() throws ApiConfigurationException, LusidTokenException {
+        thrown.expect(ApiConfigurationException.class);
+        ApiClient apiClient = apiClientBuilder.build("doesNotExist");
+    }
+
+    @Test
+    public void build_BadTokenConfigurationFile_ShouldThrowException() throws ApiConfigurationException, LusidTokenException {
+        thrown.expect(LusidTokenException.class);
+        ApiClient apiClient = apiClientBuilder.build("bad_token_credentials.json");
+    }
+
+
+}

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/ApiExceptionTests.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/ApiExceptionTests.java
@@ -3,6 +3,7 @@ package com.finbourne.lusid.utilities;
 import com.finbourne.lusid.ApiClient;
 import com.finbourne.lusid.ApiException;
 import com.finbourne.lusid.api.PortfoliosApi;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -13,7 +14,7 @@ import static org.junit.Assert.*;
 public class ApiExceptionTests {
 
     @Test
-    public void thrown_exception_tostring_contains_requestid() throws IOException, ApiException {
+    public void thrown_exception_tostring_contains_requestid() throws ApiConfigurationException, LusidTokenException {
 
         ApiClient apiClient = new ApiClientBuilder().build(CredentialsSource.credentialsFile);
 

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/KeepAuthApiClientTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/KeepAuthApiClientTest.java
@@ -23,9 +23,9 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
-public class KeepLiveApiClientTest {
+public class KeepAuthApiClientTest {
 
-    private KeepLiveApiClient keepLiveApiClient;
+    private KeepAuthApiClient keepAuthApiClient;
 
     // mock dependencies
     private ApiClient defaultApiClient;
@@ -56,25 +56,25 @@ public class KeepLiveApiClientTest {
 
         doReturn(lusidToken).when(tokenProvider).get();
 
-        keepLiveApiClient = new KeepLiveApiClient(defaultApiClient, tokenProvider);
+        keepAuthApiClient = new KeepAuthApiClient(defaultApiClient, tokenProvider);
     }
 
     @Test
     public void buildCall_ShouldUpdateAuthHeaderAndDelegateBuildCall() throws ApiException {
-        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        keepAuthApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
         verify(defaultApiClient).addDefaultHeader("Authorization", "Bearer access_01");
         verify(defaultApiClient).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
     }
 
     @Test
     public void buildCall_ShouldUpdateAuthHeaderOnEveryCall() throws ApiException, LusidTokenException {
-        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        keepAuthApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
         verify(defaultApiClient).addDefaultHeader("Authorization", "Bearer access_01");
         verify(defaultApiClient).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
 
         doReturn(anotherLusidToken).when(tokenProvider).get();
 
-        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        keepAuthApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
         verify(defaultApiClient).addDefaultHeader("Authorization", "Bearer access_02");
         verify(defaultApiClient, times(2)).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
     }
@@ -86,7 +86,7 @@ public class KeepLiveApiClientTest {
         thrown.expect(ApiException.class);
         thrown.expectCause(equalTo(lusidTokenException));
 
-        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        keepAuthApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class KeepLiveApiClientTest {
         ApiException apiException = new ApiException("An API call failure");
         doThrow(apiException).when(defaultApiClient).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
         try {
-            keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+            keepAuthApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
         } catch (ApiException e){
             assertThat(e, sameInstance(apiException));
         }

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/KeepLiveApiClientTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/KeepLiveApiClientTest.java
@@ -1,0 +1,103 @@
+package com.finbourne.lusid.utilities;
+
+import com.finbourne.lusid.ApiCallback;
+import com.finbourne.lusid.ApiClient;
+import com.finbourne.lusid.ApiException;
+import com.finbourne.lusid.Pair;
+import com.finbourne.lusid.utilities.auth.KeepAuthTokenProvider;
+import com.finbourne.lusid.utilities.auth.LusidToken;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class KeepLiveApiClientTest {
+
+    private KeepLiveApiClient keepLiveApiClient;
+
+    // mock dependencies
+    private ApiClient defaultApiClient;
+    private KeepAuthTokenProvider tokenProvider;
+
+    // mock tokens
+    private LusidToken lusidToken = new LusidToken("access_01", "refresh_01", LocalDateTime.now());
+    private LusidToken anotherLusidToken = new LusidToken("access_02", "refresh_01", LocalDateTime.now());
+
+    // call params
+    private String path = "/get_portfolios";
+    private String method = "GET";
+    private List<Pair> queryParams = new ArrayList<>();
+    private List<Pair> collectionQueryParams = new ArrayList<>();
+    private Object body = new Object();
+    private Map<String,String> headerParams = new HashMap<>();
+    private Map<String,Object> formParams = new HashMap<>();
+    private String[] authNames = new String[]{};
+    private ApiCallback apiCallback = mock(ApiCallback.class);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() throws LusidTokenException {
+        defaultApiClient = mock(ApiClient.class);
+        tokenProvider = mock(KeepAuthTokenProvider.class);
+
+        doReturn(lusidToken).when(tokenProvider).get();
+
+        keepLiveApiClient = new KeepLiveApiClient(defaultApiClient, tokenProvider);
+    }
+
+    @Test
+    public void buildCall_ShouldUpdateAuthHeaderAndDelegateBuildCall() throws ApiException {
+        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        verify(defaultApiClient).addDefaultHeader("Authorization", "Bearer access_01");
+        verify(defaultApiClient).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+    }
+
+    @Test
+    public void buildCall_ShouldUpdateAuthHeaderOnEveryCall() throws ApiException, LusidTokenException {
+        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        verify(defaultApiClient).addDefaultHeader("Authorization", "Bearer access_01");
+        verify(defaultApiClient).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+
+        doReturn(anotherLusidToken).when(tokenProvider).get();
+
+        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        verify(defaultApiClient).addDefaultHeader("Authorization", "Bearer access_02");
+        verify(defaultApiClient, times(2)).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+    }
+
+    @Test
+    public void buildCall_OnExceptionRetrievingToken_ShouldThrowApiException() throws LusidTokenException, ApiException {
+        LusidTokenException lusidTokenException = new LusidTokenException("Failed to create token for some reason");
+        doThrow(lusidTokenException).when(tokenProvider).get();
+        thrown.expect(ApiException.class);
+        thrown.expectCause(equalTo(lusidTokenException));
+
+        keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+    }
+
+    @Test
+    public void buidCall_OnUnderlyingApiClientException_ShouldRethrowExactException() throws ApiException {
+        ApiException apiException = new ApiException("An API call failure");
+        doThrow(apiException).when(defaultApiClient).buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        try {
+            keepLiveApiClient.buildCall(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, apiCallback);
+        } catch (ApiException e){
+            assertThat(e, sameInstance(apiException));
+        }
+    }
+
+}

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/LusidApiFactoryBuilderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/LusidApiFactoryBuilderIT.java
@@ -29,7 +29,7 @@ public class LusidApiFactoryBuilderIT {
 
     @Test
     public void build_WithNonExistingConfigurationFile_ShouldThrowException() throws IOException {
-        thrown.expect(IOException.class);
+        thrown.expect(RuntimeException.class);
         LusidApiFactoryBuilder.build("doesNotExist");
     }
 

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/LusidApiFactoryBuilderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/LusidApiFactoryBuilderIT.java
@@ -5,11 +5,10 @@ import com.finbourne.lusid.api.InstrumentsApi;
 import com.finbourne.lusid.api.ScopesApi;
 import com.finbourne.lusid.model.ResourceListOfInstrumentIdTypeDescriptor;
 import com.finbourne.lusid.model.ResourceListOfScopeDefinition;
+import com.finbourne.lusid.utilities.auth.LusidTokenException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.empty;
@@ -21,21 +20,27 @@ public class LusidApiFactoryBuilderIT {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void build_WithExistingConfigurationFile_ShouldReturnFactory() throws IOException, ApiException {
+    public void build_WithExistingConfigurationFile_ShouldReturnFactory() throws ApiException, ApiConfigurationException, LusidTokenException {
         LusidApiFactory lusidApiFactory = LusidApiFactoryBuilder.build(CredentialsSource.credentialsFile);
         assertThat(lusidApiFactory, is(notNullValue()));
         assertThatFactoryBuiltApiCanMakeLUSIDCalls(lusidApiFactory);
     }
 
     @Test
-    public void build_WithNonExistingConfigurationFile_ShouldThrowException() throws IOException {
-        thrown.expect(RuntimeException.class);
+    public void build_WithNonExistingConfigurationFile_ShouldThrowException() throws ApiConfigurationException, LusidTokenException {
+        thrown.expect(ApiConfigurationException.class);
         LusidApiFactoryBuilder.build("doesNotExist");
     }
 
     @Test
-    public void build_WithUnsetEnvironmentVariablesConfig_ShouldThrowException() throws IOException {
-        thrown.expect(IllegalStateException.class);
+    public void build_BadTokenConfigurationFile_ShouldThrowException() throws ApiConfigurationException, LusidTokenException {
+        thrown.expect(LusidTokenException.class);
+        LusidApiFactoryBuilder.build("bad_token_credentials.json");
+    }
+
+    @Test
+    public void build_WithUnsetEnvironmentVariablesConfig_ShouldThrowException() throws ApiConfigurationException, LusidTokenException {
+        thrown.expect(ApiConfigurationException.class);
         thrown.expectMessage("Environment variables to configure LUSID API client have not been set. See " +
                 " see https://support.lusid.com/getting-started-with-apis-sdks for details.");
         LusidApiFactoryBuilder.build();

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderIT.java
@@ -1,0 +1,61 @@
+package com.finbourne.lusid.utilities.auth;
+
+import com.finbourne.lusid.utilities.ApiConfiguration;
+import com.finbourne.lusid.utilities.ApiConfigurationBuilder;
+import com.finbourne.lusid.utilities.CredentialsSource;
+import com.finbourne.lusid.utilities.HttpClientBuilder;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class HttpLusidTokenProviderIT {
+
+    private HttpLusidTokenProvider httpLusidTokenProvider;
+
+    @Before
+    public void setUp() throws IOException {
+        ApiConfiguration apiConfiguration = new ApiConfigurationBuilder().build(CredentialsSource.credentialsFile);
+        OkHttpClient httpClient = new HttpClientBuilder().build(apiConfiguration);
+        httpLusidTokenProvider = new HttpLusidTokenProvider(apiConfiguration, httpClient);
+    }
+
+    @Test
+    public void getToken_OnNoRefreshToken_ShouldReturnNewToken(){
+        LusidToken lusidToken = httpLusidTokenProvider.getToken(Optional.empty());
+
+        assertThat(lusidToken.getAccessToken(), not(isEmptyOrNullString()));
+        assertThat(lusidToken.getRefreshToken(), not(isEmptyOrNullString()));
+        assertThat(lusidToken.getExpiresAt(), not(nullValue()));
+    }
+
+    @Test
+    public void getToken_OnRefreshToken_ShouldReturnNewRefreshedToken(){
+        LusidToken initialToken = httpLusidTokenProvider.getToken(Optional.empty());
+        LusidToken refreshedToken = httpLusidTokenProvider.getToken(Optional.of(initialToken.getRefreshToken()));
+
+        assertThat(refreshedToken.getAccessToken(), not(isEmptyOrNullString()));
+        assertThat(refreshedToken.getRefreshToken(), not(isEmptyOrNullString()));
+        assertThat(refreshedToken.getExpiresAt(), not(nullValue()));
+        assertThat(refreshedToken, not(equalTo(initialToken)));
+    }
+
+    // Error cases
+    @Test(expected = IllegalArgumentException.class)
+    public void getToken_OnBadTokenUrl() throws IOException {
+        ApiConfiguration apiConfiguration = new ApiConfigurationBuilder().build(CredentialsSource.credentialsFile);
+        OkHttpClient httpClient = new HttpClientBuilder().build(apiConfiguration);
+        apiConfiguration.setTokenUrl("invalidTokenUrl");
+
+        HttpLusidTokenProvider httpLusidTokenProvider = new HttpLusidTokenProvider(apiConfiguration, httpClient);
+        LusidToken lusidToken = httpLusidTokenProvider.getToken(Optional.empty());
+    }
+}

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderIT.java
@@ -1,9 +1,6 @@
 package com.finbourne.lusid.utilities.auth;
 
-import com.finbourne.lusid.utilities.ApiConfiguration;
-import com.finbourne.lusid.utilities.ApiConfigurationBuilder;
-import com.finbourne.lusid.utilities.CredentialsSource;
-import com.finbourne.lusid.utilities.HttpClientBuilder;
+import com.finbourne.lusid.utilities.*;
 import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,14 +17,14 @@ public class HttpLusidTokenProviderIT {
     private HttpLusidTokenProvider httpLusidTokenProvider;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() throws ApiConfigurationException {
         ApiConfiguration apiConfiguration = new ApiConfigurationBuilder().build(CredentialsSource.credentialsFile);
         OkHttpClient httpClient = new HttpClientBuilder().build(apiConfiguration);
         httpLusidTokenProvider = new HttpLusidTokenProvider(apiConfiguration, httpClient);
     }
 
     @Test
-    public void get_OnRequestingAnInitialToken_ShouldReturnNewToken(){
+    public void get_OnRequestingAnInitialToken_ShouldReturnNewToken() throws LusidTokenException {
         LusidToken lusidToken = httpLusidTokenProvider.get(Optional.empty());
 
         assertThat(lusidToken.getAccessToken(), not(isEmptyOrNullString()));
@@ -36,7 +33,7 @@ public class HttpLusidTokenProviderIT {
     }
 
     @Test
-    public void get_OnRequestingANewTokenWithRefreshing_ShouldReturnNewRefreshedToken(){
+    public void get_OnRequestingANewTokenWithRefreshing_ShouldReturnNewRefreshedToken() throws LusidTokenException {
         LusidToken initialToken = httpLusidTokenProvider.get(Optional.empty());
         LusidToken refreshedToken = httpLusidTokenProvider.get(Optional.of(initialToken.getRefreshToken()));
 
@@ -47,7 +44,7 @@ public class HttpLusidTokenProviderIT {
     }
 
     @Test
-    public void get_OnRequestingANewTokenWithoutRefreshing_ShouldReturnNewToken(){
+    public void get_OnRequestingANewTokenWithoutRefreshing_ShouldReturnNewToken() throws LusidTokenException {
         LusidToken initialToken = httpLusidTokenProvider.get(Optional.empty());
         LusidToken refreshedToken = httpLusidTokenProvider.get(Optional.empty());
 
@@ -59,7 +56,7 @@ public class HttpLusidTokenProviderIT {
 
     // Error cases
     @Test(expected = IllegalArgumentException.class)
-    public void getToken_OnBadTokenUrl() throws IOException {
+    public void getToken_OnBadTokenUrl() throws LusidTokenException, ApiConfigurationException {
         ApiConfiguration apiConfiguration = new ApiConfigurationBuilder().build(CredentialsSource.credentialsFile);
         OkHttpClient httpClient = new HttpClientBuilder().build(apiConfiguration);
         apiConfiguration.setTokenUrl("invalidTokenUrl");

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderIT.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 public class HttpLusidTokenProviderIT {
 
@@ -29,8 +27,8 @@ public class HttpLusidTokenProviderIT {
     }
 
     @Test
-    public void getToken_OnNoRefreshToken_ShouldReturnNewToken(){
-        LusidToken lusidToken = httpLusidTokenProvider.getToken(Optional.empty());
+    public void get_OnRequestingAnInitialToken_ShouldReturnNewToken(){
+        LusidToken lusidToken = httpLusidTokenProvider.get(Optional.empty());
 
         assertThat(lusidToken.getAccessToken(), not(isEmptyOrNullString()));
         assertThat(lusidToken.getRefreshToken(), not(isEmptyOrNullString()));
@@ -38,9 +36,20 @@ public class HttpLusidTokenProviderIT {
     }
 
     @Test
-    public void getToken_OnRefreshToken_ShouldReturnNewRefreshedToken(){
-        LusidToken initialToken = httpLusidTokenProvider.getToken(Optional.empty());
-        LusidToken refreshedToken = httpLusidTokenProvider.getToken(Optional.of(initialToken.getRefreshToken()));
+    public void get_OnRequestingANewTokenWithRefreshing_ShouldReturnNewRefreshedToken(){
+        LusidToken initialToken = httpLusidTokenProvider.get(Optional.empty());
+        LusidToken refreshedToken = httpLusidTokenProvider.get(Optional.of(initialToken.getRefreshToken()));
+
+        assertThat(refreshedToken.getAccessToken(), not(isEmptyOrNullString()));
+        assertThat(refreshedToken.getRefreshToken(), not(isEmptyOrNullString()));
+        assertThat(refreshedToken.getExpiresAt(), not(nullValue()));
+        assertThat(refreshedToken, not(equalTo(initialToken)));
+    }
+
+    @Test
+    public void get_OnRequestingANewTokenWithoutRefreshing_ShouldReturnNewToken(){
+        LusidToken initialToken = httpLusidTokenProvider.get(Optional.empty());
+        LusidToken refreshedToken = httpLusidTokenProvider.get(Optional.empty());
 
         assertThat(refreshedToken.getAccessToken(), not(isEmptyOrNullString()));
         assertThat(refreshedToken.getRefreshToken(), not(isEmptyOrNullString()));
@@ -56,6 +65,6 @@ public class HttpLusidTokenProviderIT {
         apiConfiguration.setTokenUrl("invalidTokenUrl");
 
         HttpLusidTokenProvider httpLusidTokenProvider = new HttpLusidTokenProvider(apiConfiguration, httpClient);
-        LusidToken lusidToken = httpLusidTokenProvider.getToken(Optional.empty());
+        LusidToken lusidToken = httpLusidTokenProvider.get(Optional.empty());
     }
 }

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderTest.java
@@ -1,20 +1,15 @@
 package com.finbourne.lusid.utilities.auth;
 
 import com.finbourne.lusid.utilities.ApiConfiguration;
-import com.finbourne.lusid.utilities.ApiConfigurationBuilder;
-import com.finbourne.lusid.utilities.CredentialsSource;
-import com.finbourne.lusid.utilities.HttpClientBuilder;
 import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.mockito.Mockito.mock;
 
 public class HttpLusidTokenProviderTest {

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/HttpLusidTokenProviderTest.java
@@ -1,0 +1,44 @@
+package com.finbourne.lusid.utilities.auth;
+
+import com.finbourne.lusid.utilities.ApiConfiguration;
+import com.finbourne.lusid.utilities.ApiConfigurationBuilder;
+import com.finbourne.lusid.utilities.CredentialsSource;
+import com.finbourne.lusid.utilities.HttpClientBuilder;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.mockito.Mockito.mock;
+
+public class HttpLusidTokenProviderTest {
+
+    private HttpLusidTokenProvider httpLusidTokenProvider;
+
+    @Before
+    public void setUp() throws IOException {
+        ApiConfiguration apiConfiguration = mock(ApiConfiguration.class);
+        OkHttpClient httpClient = mock(OkHttpClient.class);
+        httpLusidTokenProvider = new HttpLusidTokenProvider(apiConfiguration, httpClient);
+    }
+
+    @Test
+    public void calculateExpiryAtTime_ShouldApplyThirySecondCut(){
+        LocalDateTime authTime = LocalDateTime.of(2020,01,01,00,00,00);
+        int expiryIn = 3600;
+
+        LocalDateTime expiryAt = httpLusidTokenProvider.calculateExpiryAtTime(authTime, expiryIn);
+
+        assertThat("Expiry At time should be an hour ahead of the time of auth call minus a 30 second gap for " +
+                        "race condition when token is very close to expiry time and valid on retrieval but not when used.",
+                expiryAt,
+                equalTo(LocalDateTime.of(2020,01,01,00,59,30)));
+    }
+
+}

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderIT.java
@@ -1,0 +1,73 @@
+package com.finbourne.lusid.utilities.auth;
+
+import com.finbourne.lusid.utilities.ApiConfiguration;
+import com.finbourne.lusid.utilities.ApiConfigurationBuilder;
+import com.finbourne.lusid.utilities.CredentialsSource;
+import com.finbourne.lusid.utilities.HttpClientBuilder;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.mockito.Mockito.*;
+
+public class KeepAuthTokenProviderIT {
+
+    private KeepAuthTokenProvider tokenProvider;
+    private HttpLusidTokenProvider httpLusidTokenProvider;
+
+    @Before
+    public void setUp() throws IOException {
+        ApiConfiguration apiConfiguration = new ApiConfigurationBuilder().build(CredentialsSource.credentialsFile);
+        OkHttpClient httpClient = new HttpClientBuilder().build(apiConfiguration);
+        httpLusidTokenProvider = new HttpLusidTokenProvider(apiConfiguration, httpClient);
+        KeepAuthTokenProvider instanceToSpy = new KeepAuthTokenProvider(httpLusidTokenProvider);
+        tokenProvider = spy(instanceToSpy);
+    }
+
+    @Test
+    public void get_OnNoToken_ShouldReturnNewToken(){
+        LusidToken lusidToken = tokenProvider.get();
+        assertThat(lusidToken.getAccessToken(), not(isEmptyOrNullString()));
+        assertThat(lusidToken.getRefreshToken(), not(isEmptyOrNullString()));
+        assertThat(lusidToken.getExpiresAt(), not(nullValue()));
+    }
+
+    @Test
+    public void get_OnExistingAndNonExpiredToken_ShouldReturnSameToken(){
+        // first call should create a token
+        LusidToken lusidToken = tokenProvider.get();
+
+        // mock token not expired
+        doReturn(false).when(tokenProvider).isTokenExpired(lusidToken);
+
+        // second call should check for expiry
+        LusidToken nextLusidToken = tokenProvider.get();
+
+        assertThat(nextLusidToken, equalTo(lusidToken));
+    }
+
+    @Test
+    public void get_OnExistingAndExpiredToken_ShouldReturnNewToken(){
+        // first call should create a token
+        LusidToken lusidToken = tokenProvider.get();
+
+        // mock token expiry
+        doReturn(true).when(tokenProvider).isTokenExpired(lusidToken);
+
+        // second call should check for expiry
+        LusidToken nextLusidToken = tokenProvider.get();
+
+        assertThat(nextLusidToken.getAccessToken(), not(isEmptyOrNullString()));
+        assertThat(nextLusidToken.getRefreshToken(), not(isEmptyOrNullString()));
+        assertThat(nextLusidToken.getExpiresAt(), not(nullValue()));
+        assertThat(nextLusidToken, not(equalTo(lusidToken)));
+    }
+
+
+
+}

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderIT.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderIT.java
@@ -13,7 +13,8 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 public class KeepAuthTokenProviderIT {
 
@@ -30,7 +31,7 @@ public class KeepAuthTokenProviderIT {
     }
 
     @Test
-    public void get_OnNoToken_ShouldReturnNewToken(){
+    public void get_OnNoCurrentToken_ShouldReturnNewToken(){
         LusidToken lusidToken = tokenProvider.get();
         assertThat(lusidToken.getAccessToken(), not(isEmptyOrNullString()));
         assertThat(lusidToken.getRefreshToken(), not(isEmptyOrNullString()));
@@ -38,7 +39,7 @@ public class KeepAuthTokenProviderIT {
     }
 
     @Test
-    public void get_OnExistingAndNonExpiredToken_ShouldReturnSameToken(){
+    public void get_OnNonExpiredCurrentToken_ShouldReturnSameToken(){
         // first call should create a token
         LusidToken lusidToken = tokenProvider.get();
 
@@ -52,11 +53,11 @@ public class KeepAuthTokenProviderIT {
     }
 
     @Test
-    public void get_OnExistingAndExpiredToken_ShouldReturnNewToken(){
+    public void get_OnExpiredCurrentToken_ShouldReturnNewToken(){
         // first call should create a token
         LusidToken lusidToken = tokenProvider.get();
 
-        // mock token expiry
+        // mock token expired
         doReturn(true).when(tokenProvider).isTokenExpired(lusidToken);
 
         // second call should check for expiry

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
@@ -24,13 +24,13 @@ public class KeepAuthTokenProviderTest {
     }
 
     @Test
-    public void get_OnNoCurrentToken_ShouldCallLusidProviderForFullAuthentication(){
+    public void get_OnNoCurrentToken_ShouldCallLusidProviderForFullAuthentication() throws LusidTokenException {
         tokenProvider.get();
         verify(httpLusidTokenProvider, times(1)).get(Optional.empty());
     }
 
     @Test
-    public void get_OnNonExpiredCurrentToken_ShouldDoNothing(){
+    public void get_OnNonExpiredCurrentToken_ShouldDoNothing() throws LusidTokenException {
         LusidToken nonExpiredToken = mock(LusidToken.class);
         doReturn(LocalDateTime.MAX).when(nonExpiredToken).getExpiresAt();
         doReturn(nonExpiredToken).when(httpLusidTokenProvider).get(Optional.empty());
@@ -47,7 +47,7 @@ public class KeepAuthTokenProviderTest {
     }
 
     @Test
-    public void get_OnExpiredCurrentToken_ShouldCallLusidForNewRefreshedToken(){
+    public void get_OnExpiredCurrentToken_ShouldCallLusidForNewRefreshedToken() throws LusidTokenException {
         LusidToken expiredToken = mock(LusidToken.class);
         doReturn(LocalDateTime.MIN).when(expiredToken).getExpiresAt();
         doReturn("refreshToken1").when(expiredToken).getRefreshToken();

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
@@ -1,21 +1,26 @@
 package com.finbourne.lusid.utilities.auth;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class KeepAuthTokenProviderTest {
 
     private KeepAuthTokenProvider tokenProvider;
+
     // dependency mocks
     private HttpLusidTokenProvider httpLusidTokenProvider;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setUp(){
@@ -25,47 +30,100 @@ public class KeepAuthTokenProviderTest {
 
     @Test
     public void get_OnNoCurrentToken_ShouldCallLusidProviderForFullAuthentication() throws LusidTokenException {
-        tokenProvider.get();
+        LusidToken authenticatedToken = new LusidToken("access_01", "refresh_01", LocalDateTime.MAX);
+        doReturn(authenticatedToken).when(httpLusidTokenProvider).get(Optional.empty());
+
+        LusidToken currentToken = tokenProvider.get();
+
+        assertThat(currentToken, equalTo(authenticatedToken));
         verify(httpLusidTokenProvider, times(1)).get(Optional.empty());
     }
 
     @Test
     public void get_OnNonExpiredCurrentToken_ShouldDoNothing() throws LusidTokenException {
-        LusidToken nonExpiredToken = mock(LusidToken.class);
-        doReturn(LocalDateTime.MAX).when(nonExpiredToken).getExpiresAt();
+        LusidToken nonExpiredToken = new LusidToken("access_01", "refresh_01", LocalDateTime.MAX);
         doReturn(nonExpiredToken).when(httpLusidTokenProvider).get(Optional.empty());
 
-        // setup first time
-        LusidToken existingToken = tokenProvider.get();
+        // get the first token
+        LusidToken currentToken = tokenProvider.get();
 
-        // fetch token again
+        // get the next token
         LusidToken nextToken = tokenProvider.get();
 
-        assertThat(nextToken, equalTo(existingToken));
+        assertThat(nextToken, sameInstance(currentToken));
         verify(httpLusidTokenProvider, times(1)).get(Optional.empty());
         verify(httpLusidTokenProvider, times(0)).get(Optional.of(anyString()));
     }
 
     @Test
     public void get_OnExpiredCurrentToken_ShouldCallLusidForNewRefreshedToken() throws LusidTokenException {
-        LusidToken expiredToken = mock(LusidToken.class);
-        doReturn(LocalDateTime.MIN).when(expiredToken).getExpiresAt();
-        doReturn("refreshToken1").when(expiredToken).getRefreshToken();
+        LusidToken expiredToken = new LusidToken("access_01", "refresh_01", LocalDateTime.MIN);
         doReturn(expiredToken).when(httpLusidTokenProvider).get(Optional.empty());
 
-        LusidToken refreshedToken = mock(LusidToken.class);
-        doReturn(refreshedToken).when(httpLusidTokenProvider).get(Optional.of("refreshToken1"));
+        LusidToken refreshedToken = new LusidToken("access_02", "refresh_01", LocalDateTime.MAX);
+        doReturn(refreshedToken).when(httpLusidTokenProvider).get(Optional.of("refresh_01"));
 
-        // setup first time
-        LusidToken existingToken = tokenProvider.get();
+        // get the first token
+        LusidToken currentToken = tokenProvider.get();
 
-        // fetch token again
+        // get the next token
         LusidToken nextToken = tokenProvider.get();
 
-        assertThat(nextToken, not(equalTo(existingToken)));
+        assertThat(nextToken, not(equalTo(currentToken)));
         assertThat(nextToken, equalTo(refreshedToken));
         verify(httpLusidTokenProvider, times(1)).get(Optional.empty());
-        verify(httpLusidTokenProvider, times(1)).get(Optional.of("refreshToken1"));
+        verify(httpLusidTokenProvider, times(1)).get(Optional.of("refresh_01"));
+    }
+
+    @Test
+    public void get_OnExpiredRefreshToken_ShouldCallLusidProviderForFullReauthentication() throws LusidTokenException {
+        // the case where the REFRESH token itself has expired
+
+        // setup initial expired access token
+        LusidToken expiredToken = new LusidToken("access_01", "refresh_01", LocalDateTime.MIN);
+        doReturn(expiredToken).when(httpLusidTokenProvider).get(Optional.empty());
+        LusidToken currentToken = tokenProvider.get();
+
+        // throw exception on attempting to refresh with an expired REFRESH token
+        doThrow(new LusidTokenException("Refresh token has expired")).when(httpLusidTokenProvider).get(Optional.of("refresh_01"));
+        // setup a new access token via full authentication route
+        LusidToken newTokenWithNewRefresh = new LusidToken("access_02", "refresh_02", LocalDateTime.MAX);
+        doReturn(newTokenWithNewRefresh).when(httpLusidTokenProvider).get(Optional.empty());
+
+        // fetch token again. as both the access and refresh token have expired expect an exception and a full
+        // reauthentication attempt
+        LusidToken nextToken = tokenProvider.get();
+
+        assertThat(nextToken, not(equalTo(currentToken)));
+        assertThat(nextToken, equalTo(newTokenWithNewRefresh));
+        verify(httpLusidTokenProvider, times(2)).get(Optional.empty());
+        verify(httpLusidTokenProvider, times(1)).get(Optional.of("refresh_01"));
+    }
+
+    // Error Cases
+
+    @Test
+    public void get_OnFailedRemoteAuthentication_ShouldReThrowLusidTokenException() throws LusidTokenException {
+        LusidTokenException lusidTokenException = new LusidTokenException("Failed to retrieve token");
+        doThrow(lusidTokenException).when(httpLusidTokenProvider).get(Optional.empty());
+
+        thrown.expect(LusidTokenException.class);
+        tokenProvider.get();
+    }
+
+    @Test
+    public void get_OnFailedRefreshAndFailedReAuthAttempt_ShouldReThrowLusidTokenException() throws LusidTokenException {
+        LusidToken expiredToken = new LusidToken("access_01", "refresh_01", LocalDateTime.MIN);
+        doReturn(expiredToken).when(httpLusidTokenProvider).get(Optional.empty());
+
+        // get the first token
+        LusidToken currentToken = tokenProvider.get();
+
+        doThrow(new LusidTokenException("Refresh token has expired")).when(httpLusidTokenProvider).get(Optional.of("refresh_01"));
+        doThrow(new LusidTokenException("Reauthentication attempt has failed")).when(httpLusidTokenProvider).get(Optional.empty());
+
+        thrown.expect(LusidTokenException.class);
+        tokenProvider.get();
     }
 
 }

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
@@ -1,0 +1,73 @@
+package com.finbourne.lusid.utilities.auth;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class KeepAuthTokenProviderTest {
+
+    private KeepAuthTokenProvider tokenProvider;
+    // dependency mocks
+    private HttpLusidTokenProvider httpLusidTokenProvider;
+
+    @Before
+    public void setUp(){
+        httpLusidTokenProvider = mock(HttpLusidTokenProvider.class);
+        tokenProvider = new KeepAuthTokenProvider(httpLusidTokenProvider);
+    }
+
+    @Test
+    public void get_OnNoCurrentToken_ShouldCallLusidProviderForFullAuthentication(){
+        tokenProvider.get();
+        verify(httpLusidTokenProvider, times(1)).getToken(Optional.empty());
+    }
+
+    @Test
+    public void get_OnExistingTokenThatIsNotExpired_ShouldDoNothing(){
+        LusidToken nonExpiredToken = mock(LusidToken.class);
+        doReturn(LocalDateTime.MAX).when(nonExpiredToken).getExpiresAt();
+        doReturn(nonExpiredToken).when(httpLusidTokenProvider).getToken(Optional.empty());
+
+        // setup first time
+        LusidToken existingToken = tokenProvider.get();
+
+        // fetch token again
+        LusidToken nextToken = tokenProvider.get();
+
+        assertThat(nextToken, equalTo(existingToken));
+        verify(httpLusidTokenProvider, times(1)).getToken(Optional.empty());
+        verify(httpLusidTokenProvider, times(0)).getToken(Optional.of(anyString()));
+    }
+
+    @Test
+    public void get_OnExistingTokenThatIsExpired_ShouldCallLusidForNewRefreshedToken(){
+        LusidToken expiredToken = mock(LusidToken.class);
+        doReturn(LocalDateTime.MIN).when(expiredToken).getExpiresAt();
+        doReturn("refreshToken1").when(expiredToken).getRefreshToken();
+        doReturn(expiredToken).when(httpLusidTokenProvider).getToken(Optional.empty());
+
+        LusidToken refreshedToken = mock(LusidToken.class);
+        doReturn(refreshedToken).when(httpLusidTokenProvider).getToken(Optional.of("refreshToken1"));
+
+        // setup first time
+        LusidToken existingToken = tokenProvider.get();
+
+        // fetch token again
+        LusidToken nextToken = tokenProvider.get();
+
+        assertThat(nextToken, not(equalTo(existingToken)));
+        assertThat(nextToken, equalTo(refreshedToken));
+        verify(httpLusidTokenProvider, times(1)).getToken(Optional.empty());
+        verify(httpLusidTokenProvider, times(1)).getToken(Optional.of("refreshToken1"));
+    }
+
+    // Error Cases : //TODO Discuss exception cases Riz : Can refresh tokens expire
+
+}

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/auth/KeepAuthTokenProviderTest.java
@@ -26,14 +26,14 @@ public class KeepAuthTokenProviderTest {
     @Test
     public void get_OnNoCurrentToken_ShouldCallLusidProviderForFullAuthentication(){
         tokenProvider.get();
-        verify(httpLusidTokenProvider, times(1)).getToken(Optional.empty());
+        verify(httpLusidTokenProvider, times(1)).get(Optional.empty());
     }
 
     @Test
-    public void get_OnExistingTokenThatIsNotExpired_ShouldDoNothing(){
+    public void get_OnNonExpiredCurrentToken_ShouldDoNothing(){
         LusidToken nonExpiredToken = mock(LusidToken.class);
         doReturn(LocalDateTime.MAX).when(nonExpiredToken).getExpiresAt();
-        doReturn(nonExpiredToken).when(httpLusidTokenProvider).getToken(Optional.empty());
+        doReturn(nonExpiredToken).when(httpLusidTokenProvider).get(Optional.empty());
 
         // setup first time
         LusidToken existingToken = tokenProvider.get();
@@ -42,19 +42,19 @@ public class KeepAuthTokenProviderTest {
         LusidToken nextToken = tokenProvider.get();
 
         assertThat(nextToken, equalTo(existingToken));
-        verify(httpLusidTokenProvider, times(1)).getToken(Optional.empty());
-        verify(httpLusidTokenProvider, times(0)).getToken(Optional.of(anyString()));
+        verify(httpLusidTokenProvider, times(1)).get(Optional.empty());
+        verify(httpLusidTokenProvider, times(0)).get(Optional.of(anyString()));
     }
 
     @Test
-    public void get_OnExistingTokenThatIsExpired_ShouldCallLusidForNewRefreshedToken(){
+    public void get_OnExpiredCurrentToken_ShouldCallLusidForNewRefreshedToken(){
         LusidToken expiredToken = mock(LusidToken.class);
         doReturn(LocalDateTime.MIN).when(expiredToken).getExpiresAt();
         doReturn("refreshToken1").when(expiredToken).getRefreshToken();
-        doReturn(expiredToken).when(httpLusidTokenProvider).getToken(Optional.empty());
+        doReturn(expiredToken).when(httpLusidTokenProvider).get(Optional.empty());
 
         LusidToken refreshedToken = mock(LusidToken.class);
-        doReturn(refreshedToken).when(httpLusidTokenProvider).getToken(Optional.of("refreshToken1"));
+        doReturn(refreshedToken).when(httpLusidTokenProvider).get(Optional.of("refreshToken1"));
 
         // setup first time
         LusidToken existingToken = tokenProvider.get();
@@ -64,10 +64,8 @@ public class KeepAuthTokenProviderTest {
 
         assertThat(nextToken, not(equalTo(existingToken)));
         assertThat(nextToken, equalTo(refreshedToken));
-        verify(httpLusidTokenProvider, times(1)).getToken(Optional.empty());
-        verify(httpLusidTokenProvider, times(1)).getToken(Optional.of("refreshToken1"));
+        verify(httpLusidTokenProvider, times(1)).get(Optional.empty());
+        verify(httpLusidTokenProvider, times(1)).get(Optional.of("refreshToken1"));
     }
-
-    // Error Cases : //TODO Discuss exception cases Riz : Can refresh tokens expire
 
 }

--- a/sdk/src/test/resources/bad_token_credentials.json
+++ b/sdk/src/test/resources/bad_token_credentials.json
@@ -1,0 +1,11 @@
+{
+  "api" : {
+    "apiUrl": "https://some-non-existing-test-instance.lusid.com/api",
+    "tokenUrl": "https://some-non-existing-test-instance.doesnotexist.com/oauth2/doesnotexist/v1/token",
+    "clientId": "invalid-client-id",
+    "clientSecret": "none",
+    "username": "test.testing@finbourne.com",
+    "password": "none",
+    "applicationName": "non-existent"
+  }
+}


### PR DESCRIPTION
- ApiFactory now manages refreshing of the authentication token required for API calls

- Uses an extension of the ApiClient to ensure that all calls to the LUSID API are preceded by a check to ensure token is valid. On expiry a new token is generated before the API call is made.

# Pull Request Checklist

- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
