### PR TITLE
DEV-8297 : Support loading configuration files from absolute paths

### DIFF
--- a/sdk/src/main/java/com/finbourne/lusid/utilities/FileConfigurationLoader.java
+++ b/sdk/src/main/java/com/finbourne/lusid/utilities/FileConfigurationLoader.java
@@ -41,7 +41,7 @@ public class FileConfigurationLoader {
         return (configFile.exists()) ? Optional.of(configFile) : Optional.empty();
     }
 
-    // Created in own methods for test mocking purposes.
+    // factory methods for test mocking purposes.
     ClassLoader getClassLoader(){
         return getClass().getClassLoader();
     }

--- a/sdk/src/test/integration/java/com/finbourne/lusid/utilities/ApiConfigurationBuilderTests.java
+++ b/sdk/src/test/integration/java/com/finbourne/lusid/utilities/ApiConfigurationBuilderTests.java
@@ -5,6 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static com.finbourne.lusid.utilities.TestContants.DUMMY_CREDENTIALS_FILE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
@@ -26,7 +27,7 @@ public class ApiConfigurationBuilderTests {
         doReturn(emptyConfigFromEnvVariables()).when(apiConfigurationBuilder)
                 .getApiConfigurationFromEnvironmentVariables();
 
-        ApiConfiguration apiConfiguration = apiConfigurationBuilder.build("dummy_credentials.json");
+        ApiConfiguration apiConfiguration = apiConfigurationBuilder.build(DUMMY_CREDENTIALS_FILE);
 
         assertThat(apiConfiguration.getApiUrl(), equalTo("https://some-non-existing-test-instance.lusid.com/api"));
         assertThat(apiConfiguration.getTokenUrl(), equalTo("https://some-non-existing-test-instance.doesnotexist.com/oauth2/doesnotexist/v1/token"));

--- a/sdk/src/test/integration/java/com/finbourne/lusid/utilities/FileConfigurationLoaderTests.java
+++ b/sdk/src/test/integration/java/com/finbourne/lusid/utilities/FileConfigurationLoaderTests.java
@@ -1,0 +1,48 @@
+package com.finbourne.lusid.utilities;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.finbourne.lusid.utilities.TestContants.DUMMY_CREDENTIALS_FILE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class FileConfigurationLoaderTests {
+
+    private FileConfigurationLoader fileConfigurationLoader;
+
+    @Before
+    public void setUp(){
+        fileConfigurationLoader = new FileConfigurationLoader();
+    }
+
+    @Test
+    public void loadConfiguration_FromResources_ShouldLoadConfigFile() throws IOException {
+        File credentialsFile = fileConfigurationLoader.loadConfiguration(DUMMY_CREDENTIALS_FILE);
+        assertTrue(credentialsFile.exists());
+        assertThat(credentialsFile.getName(), equalTo(DUMMY_CREDENTIALS_FILE));
+    }
+
+    @Test
+    public void loadConfiguration_FromAbsolutePath_ShouldLoadConfigFile() throws IOException {
+        String dummyCredAbsPath = getAbsolutePathOfDummyCredentialsFile();
+        File credentialsFile = fileConfigurationLoader.loadConfiguration(dummyCredAbsPath);
+        assertTrue(credentialsFile.exists());
+        assertThat(credentialsFile.getName(), equalTo(DUMMY_CREDENTIALS_FILE));
+    }
+
+    @Test(expected = IOException.class)
+    public void loadConfiguration_FromNonExistingFile_ShouldThrowException() throws IOException {
+        fileConfigurationLoader.loadConfiguration("does_not_exist.json");
+    }
+
+    private String getAbsolutePathOfDummyCredentialsFile(){
+        return new File(getClass().getClassLoader().getResource(DUMMY_CREDENTIALS_FILE).getFile()).getAbsolutePath();
+    }
+
+
+}

--- a/sdk/src/test/integration/java/com/finbourne/lusid/utilities/TestContants.java
+++ b/sdk/src/test/integration/java/com/finbourne/lusid/utilities/TestContants.java
@@ -1,0 +1,7 @@
+package com.finbourne.lusid.utilities;
+
+public class TestContants {
+
+    public final static String DUMMY_CREDENTIALS_FILE = "dummy_credentials.json";
+
+}

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/FileConfigurationLoaderTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/FileConfigurationLoaderTest.java
@@ -1,0 +1,75 @@
+package com.finbourne.lusid.utilities;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class FileConfigurationLoaderTest {
+
+    private FileConfigurationLoader fileConfigurationLoader;
+
+    // mock dependencies
+    private ClassLoader classLoader;
+    private File file;
+    private URL configURL;
+
+    // param
+    private String configFilePath = "/home/dir/secrets.json";
+    private String configFileUrl = "file:/home/dir/secrets.json";
+
+    @Before
+    public void setUp() throws MalformedURLException {
+        classLoader = mock(ClassLoader.class);
+        file = mock(File.class);
+        configURL = new URL(configFileUrl);
+        fileConfigurationLoader = spy(new FileConfigurationLoader());
+
+        doReturn(classLoader).when(fileConfigurationLoader).getClassLoader();
+        doReturn(file).when(fileConfigurationLoader).getFile(configFilePath);
+    }
+
+    @Test
+    public void loadConfiguration_NotInResources_ShouldLoadAbsolutePath() throws IOException {
+        // mock class loader not finding URL in resources
+        doReturn(null).when(classLoader).getResource(configFilePath);
+        // mock file existing in absolute path
+        doReturn(true).when(file).exists();
+
+        // verify returned the file from the absolute path
+        File result = fileConfigurationLoader.loadConfiguration(configFilePath);
+        assertThat(result, equalTo(file));
+    }
+
+    @Test
+    public void loadConfiguration_InResources_ShouldLoadFromResource() throws IOException {
+        // mock class loader finding URL in resources
+        doReturn(configURL).when(classLoader).getResource(configFilePath);
+        // ensure not returning file from absolute path
+        doReturn(false).when(file).exists();
+
+        // verify returned the file from resources
+        File result = fileConfigurationLoader.loadConfiguration(configFilePath);
+        // check name not absolute path to keep this test platform agnostic
+        assertThat(result.getName(), equalTo("secrets.json"));
+    }
+
+    @Test(expected = IOException.class)
+    public void loadConfiguration_NotInResourcesAndPathDoesNotExist_ShouldThrowException() throws IOException {
+        // mock class loader not finding URL in resources
+        doReturn(null).when(classLoader).getResource(configFilePath);
+        // mock file does not exist in absolute path
+        doReturn(false).when(file).exists();
+
+        // should throw an exception if nothing has been found
+        fileConfigurationLoader.loadConfiguration(configFilePath);
+    }
+
+}

--- a/sdk/src/test/unit/java/com/finbourne/lusid/utilities/FileConfigurationLoaderTest.java
+++ b/sdk/src/test/unit/java/com/finbourne/lusid/utilities/FileConfigurationLoaderTest.java
@@ -52,13 +52,15 @@ public class FileConfigurationLoaderTest {
     public void loadConfiguration_InResources_ShouldLoadFromResource() throws IOException {
         // mock class loader finding URL in resources
         doReturn(configURL).when(classLoader).getResource(configFilePath);
-        // ensure not returning file from absolute path
-        doReturn(false).when(file).exists();
+        // file exists if in resources
+        doReturn(true).when(file).exists();
 
         // verify returned the file from resources
         File result = fileConfigurationLoader.loadConfiguration(configFilePath);
-        // check name not absolute path to keep this test platform agnostic
+        // verify getName() and not getAbsolutePath() to keep this test platform agnostic
         assertThat(result.getName(), equalTo("secrets.json"));
+        // verify we did not try and load from absolute path if already found in resources
+        verify(fileConfigurationLoader, times(0)).getFile(anyString());
     }
 
     @Test(expected = IOException.class)


### PR DESCRIPTION
DEV-8297 : Support loading credential files from absolute paths

    - Added logic to first attempt load from classloader resource and fall
      back to loading from absolute path

# Pull Request Checklist

- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
