### PR TITLE
PLAT-650: Make changes to instruments tests for scoped instruments

### DIFF
--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/marketdata/Instruments.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/marketdata/Instruments.java
@@ -14,6 +14,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.finbourne.lusid.utilities.TestDataUtilities.DefaultScope;
 import static com.finbourne.lusid.utilities.TestDataUtilities.TutorialScope;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -133,7 +134,8 @@ public class Instruments {
                             }
                         })}
 
-        }).collect(Collectors.toMap(data -> (String)data[0], data -> (InstrumentDefinition)data[1])));
+            }).collect(Collectors.toMap(data -> (String)data[0], data -> (InstrumentDefinition)data[1])),
+            DefaultScope);
 
         assertThat(upsertInstrumentsResponse.getValues().size(), is(equalTo(5)));
     }
@@ -149,7 +151,7 @@ public class Instruments {
          */
 
         GetInstrumentsResponse lookedUpInstruments = instrumentsApi.getInstruments(FIGI_SCHEME, Arrays.asList("BBG000C6K6G9"),
-                null, null, Arrays.asList(ISIN_PROPERTY_KEY, SEDOL_PROPERTY_KEY));
+                null, null, Arrays.asList(ISIN_PROPERTY_KEY, SEDOL_PROPERTY_KEY), DefaultScope);
 
         assertThat(lookedUpInstruments.getValues(), hasKey("BBG000C6K6G9"));
 
@@ -189,7 +191,7 @@ public class Instruments {
         final int pageSize = 5;
 
         //    List the instruments restricting, the number that are returned
-        PagedResourceListOfInstrument instruments = instrumentsApi.listInstruments(null, null, null, null, null, pageSize, null, null);
+        PagedResourceListOfInstrument instruments = instrumentsApi.listInstruments(null, null, null, null, null, pageSize, null, null, DefaultScope);
 
         assertThat(instruments.getValues().size(), is(equalTo(pageSize)));
     }
@@ -201,7 +203,7 @@ public class Instruments {
         List<String>    figis = Arrays.asList("BBG000C6K6G9", "BBG000C04D57", "BBG000FV67Q4");
 
         //  Get a set of instruments querying by FIGIs
-        GetInstrumentsResponse instruments = instrumentsApi.getInstruments("Figi", figis, null, null, null);
+        GetInstrumentsResponse instruments = instrumentsApi.getInstruments("Figi", figis, null, null, null, DefaultScope);
 
         for (String figi : figis) {
             assertThat(instruments.getValues(), hasKey(figi));
@@ -220,13 +222,15 @@ public class Instruments {
         instrumentsApi.upsertInstrumentsProperties(Collections.singletonList(new UpsertInstrumentPropertyRequest()
                 .identifierType(FIGI_SCHEME)
                 .identifier(figi)
-                .properties(Collections.singletonList(new Property().key(propertyKey).value(propertyValue)))));
+                .properties(Collections.singletonList(new Property().key(propertyKey).value(propertyValue)))),
+                DefaultScope);
 
         Instrument instrument = instrumentsApi.getInstrument(
                 FIGI_SCHEME,
                 figi,
                 null, null,
-                Collections.singletonList(propertyKey)
+                Collections.singletonList(propertyKey),
+                DefaultScope
         );
 
         assertThat(instrument.getProperties(), hasSize(greaterThanOrEqualTo(1)));

--- a/sdk/src/test/unit/java/com/finbourne/lusid/utilities/InstrumentLoader.java
+++ b/sdk/src/test/unit/java/com/finbourne/lusid/utilities/InstrumentLoader.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.finbourne.lusid.utilities.TestDataUtilities.DefaultScope;
+
 /*
     Utility to load a set of instruments into LUSID
  */
@@ -33,12 +35,13 @@ public class InstrumentLoader {
     public List<String> loadInstruments() throws ApiException {
 
         UpsertInstrumentsResponse instrumentsResponse = instrumentsApi.upsertInstruments(Stream.of(new Object[][] {
-            { "request1", new InstrumentDefinition().name("ASTRAZENECA PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000C0YGH4")); }}) },
-            { "request2", new InstrumentDefinition().name("CENTRICA PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000BPFPZ1")); }}) },
-            { "request3", new InstrumentDefinition().name("DIAGEO PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000BS69D5")); }}) },
-            { "request4", new InstrumentDefinition().name("GLAXOSMITHKLINE PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000CT5GJ1")); }}) },
-            { "request5", new InstrumentDefinition().name("MARKS & SPENCER GROUP PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000BDTRV3")); }}) }
-        }).collect(Collectors.toMap(data -> (String)data[0], data -> (InstrumentDefinition)data[1])));
+                { "request1", new InstrumentDefinition().name("ASTRAZENECA PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000C0YGH4")); }}) },
+                { "request2", new InstrumentDefinition().name("CENTRICA PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000BPFPZ1")); }}) },
+                { "request3", new InstrumentDefinition().name("DIAGEO PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000BS69D5")); }}) },
+                { "request4", new InstrumentDefinition().name("GLAXOSMITHKLINE PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000CT5GJ1")); }}) },
+                { "request5", new InstrumentDefinition().name("MARKS & SPENCER GROUP PLC").identifiers(new HashMap<String, InstrumentIdValue>() {{ put("Figi", new InstrumentIdValue().value("BBG000BDTRV3")); }}) }
+            }).collect(Collectors.toMap(data -> (String)data[0], data -> (InstrumentDefinition)data[1])),
+            DefaultScope);
 
         return instrumentsResponse
                 .getValues()

--- a/sdk/src/test/unit/java/com/finbourne/lusid/utilities/TestDataUtilities.java
+++ b/sdk/src/test/unit/java/com/finbourne/lusid/utilities/TestDataUtilities.java
@@ -13,6 +13,7 @@ import static junit.framework.TestCase.assertEquals;
 
 public class TestDataUtilities {
 
+    public static String DefaultScope = "default";
     public static String TutorialScope = "Testdemo";
     public static String MarketDataScope = "FinbourneMarketData";
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

The tests that use the instruments api will have to change with the introduction of scoped instruments. Most instrument api endpoints now have an extra parameter, and Java does not support optional parameters.

This PR won't be committed until the sdk has been upgraded when scoped instruments is merged. I have tested this locally by pushing a custom sdk to maven.

I have opted to explicitly pass the default scope, but we could explicitly pass null, and it would be the same result.