### PR TITLE
CTECH-1321: Updating GetTransactions calls with new showCancelledTran…

### DIFF
--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Bitemporal.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Bitemporal.java
@@ -87,26 +87,26 @@ public class Bitemporal {
         Thread.sleep(500);
 
         //  list transactions
-        VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch1, null, null, null, null);
+        VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch1, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch1),3, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch1);
         printTransactions.accept(transactions.getValues());
 
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch2, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch2, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch2),4, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch2);
         printTransactions.accept(transactions.getValues());
 
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch3, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch3, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch3), 5, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch3);
         printTransactions.accept(transactions.getValues());
 
         //  latest transactions
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, null, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(5, transactions.getValues().size());
         System.out.println("transactions at " + OffsetDateTime.now());

--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Portfolios.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Portfolios.java
@@ -167,7 +167,7 @@ public class Portfolios {
 
         //    Retrieve the transaction
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -240,7 +240,7 @@ public class Portfolios {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());

--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Transactions.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Transactions.java
@@ -80,7 +80,7 @@ public class Transactions {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -126,7 +126,7 @@ public class Transactions {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -179,14 +179,14 @@ public class Transactions {
         transactionPortfoliosApi.upsertTransactions(TutorialScope, portfolioId, Arrays.asList(tx1, tx2, tx3));
 
         List<Transaction> txsBeforeDeletion = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId,
-                null, null, null, null, null, null, null).getValues();
+                null, null, null, null, null, null, null, null).getValues();
         assertEquals(3, txsBeforeDeletion.size());
 
         List<String> txIdsToDelete = txsBeforeDeletion.stream().map(Transaction::getTransactionId).collect(Collectors.toList());
         transactionPortfoliosApi.cancelTransactions(TutorialScope, portfolioId, txIdsToDelete);
 
         List<Transaction> txsAfterDeletion = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId,
-                null, null, null, null, null, null, null).getValues();
+                null, null, null, null, null, null, null, null).getValues();
 
         assertEquals(0, txsAfterDeletion.size());
     }


### PR DESCRIPTION
…sactions parameter (passing in null)

# Pull Request Checklist

- [X] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [X] Raised the PR against the `develop` branch

# Description of the PR

A new "showCancelledTransactions" boolean field is being added to the LUSID GetTransactions endpoint. As this will generate new parameters all calls to GetTransactions need to be updated with the new parameter (the default value is null and this is what I have used in all cases).
