### PR TITLE
remove unused start & add sortby parameter from endpoints for PLAT-2934

### DIFF
--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Bitemporal.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Bitemporal.java
@@ -87,26 +87,26 @@ public class Bitemporal {
         Thread.sleep(500);
 
         //  list transactions
-        VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch1, null, null, null, null, null);
+        VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch1, null, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch1),3, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch1);
         printTransactions.accept(transactions.getValues());
 
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch2, null, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch2, null, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch2),4, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch2);
         printTransactions.accept(transactions.getValues());
 
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch3, null, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch3, null, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch3), 5, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch3);
         printTransactions.accept(transactions.getValues());
 
         //  latest transactions
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, null, null, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, null, null, null, null, null, null, null);
 
         assertEquals(5, transactions.getValues().size());
         System.out.println("transactions at " + OffsetDateTime.now());

--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Orders.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Orders.java
@@ -388,7 +388,6 @@ public class Orders
                 null,
                 null,
                 null,
-                null,
                 "Quantity gt 100 and Scope eq '" + testScope + "' and Id in '" + order1Filter + "', '" + order2Filter + "', '" + order3Filter + "'",
                 null)
                 .getValues();

--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Portfolios.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Portfolios.java
@@ -167,7 +167,7 @@ public class Portfolios {
 
         //    Retrieve the transaction
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -240,7 +240,7 @@ public class Portfolios {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -269,7 +269,7 @@ public class Portfolios {
         }
 
         //    Retrieve the list of portfolios from a given scope
-        ResourceListOfPortfolio portfolios = portfoliosApi.listPortfoliosForScope(scope, null, null, null, null, null, null, null, null, null);
+        ResourceListOfPortfolio portfolios = portfoliosApi.listPortfoliosForScope(scope, null, null, null, null, null, null, null, null);
 
         assertThat(portfolios.getValues().size(), is(equalTo(10)));
     }

--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Reconciliation.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Reconciliation.java
@@ -98,7 +98,7 @@ public class Reconciliation {
                         .asAt(lastAsAt)
         );
 
-        ResourceListOfReconciliationBreak breaks = reconciliationsApi.reconcileHoldings(null, null, null, null, reconciliationRequest);
+        ResourceListOfReconciliationBreak breaks = reconciliationsApi.reconcileHoldings(null, null, null, reconciliationRequest);
 
         for (ReconciliationBreak value : breaks.getValues()) {
             System.out.println(String.format("%s\t%f\t%f", value.getInstrumentUid(), value.getDifferenceUnits(), value.getDifferenceCost().getAmount()));

--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Transactions.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/ibor/Transactions.java
@@ -80,7 +80,7 @@ public class Transactions {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -126,7 +126,7 @@ public class Transactions {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -179,14 +179,14 @@ public class Transactions {
         transactionPortfoliosApi.upsertTransactions(TutorialScope, portfolioId, Arrays.asList(tx1, tx2, tx3));
 
         List<Transaction> txsBeforeDeletion = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId,
-                null, null, null, null, null, null, null, null).getValues();
+                null, null, null, null, null, null, null, null, null).getValues();
         assertEquals(3, txsBeforeDeletion.size());
 
         List<String> txIdsToDelete = txsBeforeDeletion.stream().map(Transaction::getTransactionId).collect(Collectors.toList());
         transactionPortfoliosApi.cancelTransactions(TutorialScope, portfolioId, txIdsToDelete);
 
         List<Transaction> txsAfterDeletion = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId,
-                null, null, null, null, null, null, null, null).getValues();
+                null, null, null, null, null, null, null, null, null).getValues();
 
         assertEquals(0, txsAfterDeletion.size());
     }

--- a/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/marketdata/Instruments.java
+++ b/sdk/src/test/tutorial/java/com/finbourne/lusid/tutorials/marketdata/Instruments.java
@@ -191,7 +191,7 @@ public class Instruments {
         final int pageSize = 5;
 
         //    List the instruments restricting, the number that are returned
-        PagedResourceListOfInstrument instruments = instrumentsApi.listInstruments(null, null, null, null, null, pageSize, null, null, DefaultScope, null);
+        PagedResourceListOfInstrument instruments = instrumentsApi.listInstruments(null, null, null, null, pageSize, null, null, DefaultScope, null);
 
         assertThat(instruments.getValues().size(), is(equalTo(pageSize)));
     }


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Tests passed locally
Removes start parameter from usages of it in the SDK tests, following PLAT-2934
Also adds SortBy parameter for transactions, which was added a few months ago